### PR TITLE
Fix yarn cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,14 @@ jobs:
           key: ${{ runner.os }}-yarn-${{secrets.ACTIONS_CACHE_VERSION}}-${{ hashFiles('/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      - name: Fetch/Save cypress cache
+        uses: actions/cache@v2
+        id: cypress-cache
+        with:
+          path: /home/runner/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{secrets.ACTIONS_CACHE_VERSION}}-${{ hashFiles('/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cypress-
       - name: install dependencies
         run: yarn install --immutable
       - name: Ensure node_modules are up to date in the cache
@@ -127,11 +135,18 @@ jobs:
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{secrets.ACTIONS_CACHE_VERSION}}-${{ hashFiles('/yarn.lock') }}
+      - name: Fetch/Save cypress cache
+        uses: actions/cache@v2
+        id: cypress-cache
+        with:
+          path: /home/runner/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{secrets.ACTIONS_CACHE_VERSION}}-${{ hashFiles('/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cypress-
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:
-          install-command: yarn --immutable
-          # install: false
+          install: false
           build: yarn build:web-app
           start: yarn start:web-app
           wait-on: "http://localhost:3000"


### PR DESCRIPTION
# Feature

## Work performed

- Cherrypicked @basile-d  commit adding cache versioning in Github actions
- Updated yarn command to get the yarn cache folder following yarn v2 update
- Add Github cache for cypress cache folder

## Results

Faster CI

## Problems encountered

No way to clear the Github action cache. https://stackoverflow.com/a/64819132