### PR TITLE
Fix path to yarn.lock in github cache action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,8 +141,6 @@ jobs:
         with:
           path: /home/runner/.cache/Cypress
           key: ${{ runner.os }}-cypress-${{secrets.ACTIONS_CACHE_VERSION}}-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cypress-
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:


### PR DESCRIPTION
# Enhancement

Fix yarn.lock cache key in github actions

## Work performed
- We changed the yarn cache key path from `/yarn.lock` to `yarn.lock`. The `/` was making Github cache action to search the file at the root of the runner. Thus, all our hash files were empty.
- Removed a `restore keys` for cypress as it wasn't needed
