### PR TITLE
Change cursor depending on selected tool and hovered element

### DIFF
--- a/typescript/web-app/src/components/labelling-tool/openlayers-map/openlayers-map.tsx
+++ b/typescript/web-app/src/components/labelling-tool/openlayers-map/openlayers-map.tsx
@@ -94,11 +94,13 @@ export const OpenlayersMap = () => {
       if (!mapRef.current) return;
       const target = mapRef.current.getTarget() as HTMLElement;
 
-      if (selectedTool === Tools.BOUNDING_BOX) {
+      if (e.dragging) {
+        target.style.cursor = "grabbing";
+      } else if (selectedTool === Tools.BOUNDING_BOX) {
         target.style.cursor = "crosshair";
       } else if (selectedTool === Tools.SELECTION) {
         const hit = mapRef.current.hasFeatureAtPixel(e.pixel);
-        target.style.cursor = hit ? "pointer" : "move";
+        target.style.cursor = hit ? "pointer" : "grab";
       } else {
         target.style.cursor = "default";
       }


### PR DESCRIPTION
# Feature

It changes the cursor regarding what user is doing.

## Work performed

When bounding box tool is selected the cursor is set to crosshair.
When select tool is selected the cursor is set to move unless it is hover a feature it is set to pointer.
<!--- Concisely describe what was done, this will appear in the public changelog -->

## Results

The cursor now reflects what actions are possible.

![cursor-moves](https://user-images.githubusercontent.com/13099512/122063647-bce68080-cdf0-11eb-8c4e-1f32594379c9.gif)

<!--- Does this MR fully implement the new feature? If not why? Create and link new issues. -->

## Problems encountered

<!--- Explain problems that were encountered when implementing this MR -->

## Caveats

<!--- Any particular attention point with what you did? -->
Since it does not impact data and it is hard to test without screenshot comparison we decided not to test it for the moment.

## Resolved issues

<!--- List references to issues that this PR resolves -->
Fix #30 

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
