### PR TITLE
Fix a bug that prevent to unzoom openlayers when zooming the browser

### DIFF
--- a/typescript/web-app/src/components/labelling-tool/openlayers-map/openlayers-map.tsx
+++ b/typescript/web-app/src/components/labelling-tool/openlayers-map/openlayers-map.tsx
@@ -190,11 +190,11 @@ export const OpenlayersMap = () => {
                     );
                     return false;
                   }}
-                  args={{ 
+                  args={{
                     extent,
                     maxResolution: resolution,
                     // Max zoom = 16 pixels of screen per pixel of image
-                    minResolution: 1.0 / 16.0 
+                    minResolution: 1.0 / 16.0,
                   }}
                   center={center}
                   initialProjection={projection}


### PR DESCRIPTION
# Feature

When the user was zooming using browser features the current image in openlayers was cropped and the user was unable to unzoom using openlayers functionnality.

## Work performed

<!--- Concisely describe what was done, this will appear in the public changelog -->
On the view the setter for maxResolution does not exist so react-openlayers-fiber tries to brute force it. Unfortunately, it does not have any effect.

## Results

<!--- Does this MR fully implement the new feature? If not why? Create and link new issues. -->
![zoom-browser](https://user-images.githubusercontent.com/13099512/123424956-cd051980-d5c1-11eb-89a2-0b3cdbbaa11e.gif)

## Problems encountered

<!--- Explain problems that were encountered when implementing this MR -->
Surprisingly, there is no proper way to detect zoom across browsers 😱

## Caveats

<!--- Any particular attention point with what you did? -->
A view padding is defined to have a good looking feeling. However as you zoom in since it is pixels it does not scale. It because bigger regarding the available size.

## Resolved issues

<!--- List references to issues that this PR resolves -->
Fix #178 

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
