### PR TITLE
Fix breadcrumb ellipsis on really small screens

### DIFF
--- a/typescript/web-app/src/pages/images/[id].tsx
+++ b/typescript/web-app/src/pages/images/[id].tsx
@@ -9,6 +9,7 @@ import {
   Spinner,
   Box,
   Flex,
+  chakra,
 } from "@chakra-ui/react";
 import gql from "graphql-tag";
 import dynamic from "next/dynamic";
@@ -19,6 +20,8 @@ import { Meta } from "../../components/meta";
 import { Layout } from "../../components/layout";
 import type { Image } from "../../graphql-types.generated";
 import { Gallery } from "../../components/gallery";
+
+const ArrowRightIcon = chakra(RiArrowRightSLine);
 
 // The dynamic import is needed because openlayers use web apis that are not available
 // in NodeJS, like `Blob`, so it crashes when rendering in NextJS server side.
@@ -74,8 +77,12 @@ const ImagePage = () => {
       <Layout
         topBarLeftContent={
           <Breadcrumb
+            overflow="hidden"
+            textOverflow="ellipsis"
+            whiteSpace="nowrap"
             spacing="8px"
-            separator={<RiArrowRightSLine color="gray.500" />}
+            sx={{ "*": { display: "inline !important" } }}
+            separator={<ArrowRightIcon color="gray.500" />}
           >
             <BreadcrumbItem>
               <NextLink href="/images">
@@ -84,14 +91,7 @@ const ImagePage = () => {
             </BreadcrumbItem>
 
             <BreadcrumbItem isCurrentPage>
-              <Text
-                maxWidth="20rem"
-                textOverflow="ellipsis"
-                whiteSpace="nowrap"
-                overflow="hidden"
-              >
-                {imageName}
-              </Text>
+              <Text>{imageName}</Text>
             </BreadcrumbItem>
           </Breadcrumb>
         }


### PR DESCRIPTION
# Feature

On small screen the breadcrumb is displayed on two lines.

## Work performed

It changes the css implementation to apply the text ellipsis on the whole breadcrumb rather on the last part.
<!--- Concisely describe what was done, this will appear in the public changelog -->

## Results

![image](https://user-images.githubusercontent.com/13099512/124102200-6f108000-da60-11eb-8ff3-4e7a4608c137.png)

<!--- Does this MR fully implement the new feature? If not why? Create and link new issues. -->

## Problems encountered

It uses sx prop to change internal css of chakra ui.
<!--- Explain problems that were encountered when implementing this MR -->

## Caveats

<!--- Any particular attention point with what you did? -->

## Resolved issues

Fix #254 
<!--- List references to issues that this PR resolves -->

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
