### PR TITLE
Fix class search bind with "/"

### DIFF
--- a/typescript/web-app/src/components/class-selection-popover/class-selection-popover.tsx
+++ b/typescript/web-app/src/components/class-selection-popover/class-selection-popover.tsx
@@ -157,9 +157,17 @@ export const ClassSelectionPopover = ({
   const searchInputRef = useRef<HTMLInputElement | null>(null);
 
   useHotkeys(
-    keymap.focusLabelClassSearch.key,
+    // "/" key doesn't seem to be recognised on AZERTY keyboards, so we use "*" to catch any input.
+    "*",
     (keyboardEvent) => {
-      if (activateShortcuts && searchInputRef.current != null) {
+      if (
+        // Manually checks if input is bound in keymap
+        keymap.focusLabelClassSearch.key
+          .split(",")
+          .includes(keyboardEvent.key) &&
+        activateShortcuts &&
+        searchInputRef.current != null
+      ) {
         searchInputRef.current.focus();
         keyboardEvent.preventDefault();
       }


### PR DESCRIPTION
# Feature

## Work performed

"/" & "F" keys now focus on the class search on any keyboard.

## Results

## Problems encountered

hotkeys-js seems to have strange mapping issues with listeners.

## Caveats

"/" hotkey isn't detected on AZERTY keyboards, so we catch any input and check against binds afterwards.

## Resolved issues

Fixes #237

## Newly raised issues