### PR TITLE
Add link to documentation in website

### DIFF
--- a/typescript/web/src/components/website/Footer/LinkGrid.tsx
+++ b/typescript/web/src/components/website/Footer/LinkGrid.tsx
@@ -31,6 +31,11 @@ export const LinkGrid = (props: SimpleGridProps) => (
         <NextLink href="/posts">
           <Link href="/posts">Blog</Link>
         </NextLink>
+        <NextLink href="https://labelflow.gitbook.io/labelflow/">
+          <Link href="https://labelflow.gitbook.io/labelflow/">
+            Documentation
+          </Link>
+        </NextLink>
       </Stack>
     </Box>
   </SimpleGrid>

--- a/typescript/web/src/components/website/Navbar/NavLink.tsx
+++ b/typescript/web/src/components/website/Navbar/NavLink.tsx
@@ -33,6 +33,7 @@ const DesktopNavLink = React.forwardRef<HTMLAnchorElement, NavLinkProps>(
             color: "brand.600",
             fontWeight: "bold",
           }}
+          href={href}
         />
       </NextLink>
     );
@@ -53,6 +54,7 @@ export const MobileNavLink = (props: NavLinkProps) => {
         height="14"
         fontWeight="semibold"
         borderBottomWidth="1px"
+        href={href}
         {...rest}
       />
     </NextLink>

--- a/typescript/web/src/components/website/Navbar/_data.tsx
+++ b/typescript/web/src/components/website/Navbar/_data.tsx
@@ -48,4 +48,5 @@ export const links: Link[] = [
   { label: "Pricing", href: "/pricing" },
   { label: "About", href: "/about" },
   { label: "Blog", href: "/posts" },
+  { label: "Documentation", href: "https://labelflow.gitbook.io/labelflow/" },
 ];


### PR DESCRIPTION
# Feature

## Work performed

- Added a link to the documentation page in the website's nav bar and footer

## Results

<img width="1680" alt="Screenshot 2021-09-08 at 15 38 35" src="https://user-images.githubusercontent.com/17384901/132530437-55e66d4f-f5f1-4a1d-bf3e-264aed1ec2f1.png">
<img width="1680" alt="Screenshot 2021-09-08 at 15 38 44" src="https://user-images.githubusercontent.com/17384901/132530447-a9825ce5-0a2a-4494-80f1-eb6887d7104f.png">

## Resolved issues

Closes #419 
