### PR TITLE
Prefetch previous and next images

### DIFF
--- a/typescript/web/src/components/labelling-tool/openlayers-map/openlayers-map.tsx
+++ b/typescript/web/src/components/labelling-tool/openlayers-map/openlayers-map.tsx
@@ -28,6 +28,7 @@ import {
   DrawingToolState,
 } from "../../../connectors/labelling-state";
 import { theme } from "../../../theme";
+import { useImagePrefecthing } from "../../../hooks/use-image-prefetching";
 
 const empty: any[] = [];
 
@@ -116,6 +117,8 @@ export const OpenlayersMap = () => {
     variables: { id: imageId },
     skip: !imageId,
   }).data?.image;
+
+  useImagePrefecthing();
 
   const client = useApolloClient();
   const [containerRef, bounds] = useMeasure();

--- a/typescript/web/src/components/welcome-manager/welcome-modal.tsx
+++ b/typescript/web/src/components/welcome-manager/welcome-modal.tsx
@@ -113,7 +113,7 @@ const performWelcomeWorkflow = async ({
       getDatasetsResult?.datasets == null
         ? undefined
         : getDatasetsResult?.datasets.filter(
-            (dataset: DatasetType) => dataset.name === "Demo dataset"
+            (dataset: DatasetType) => dataset.name === "Tutorial dataset"
           )?.[0] ?? undefined;
 
     if (!demoDataset) {

--- a/typescript/web/src/hooks/use-image-prefetching.ts
+++ b/typescript/web/src/hooks/use-image-prefetching.ts
@@ -1,0 +1,72 @@
+import { gql, useQuery } from "@apollo/client";
+import { useEffect } from "react";
+import { useImagesNavigation } from "./use-images-navigation";
+
+const imageQuery = gql`
+  query image($id: ID!) {
+    image(where: { id: $id }) {
+      id
+      width
+      height
+      url
+    }
+  }
+`;
+
+const getImageLabelsQuery = gql`
+  query getImageLabels($imageId: ID!) {
+    image(where: { id: $imageId }) {
+      id
+      labels {
+        id
+        x
+        y
+        width
+        height
+        labelClass {
+          id
+          color
+        }
+        geometry {
+          type
+          coordinates
+        }
+      }
+    }
+  }
+`;
+
+export const useImagePrefecthing = () => {
+  const { nextImageId, previousImageId } = useImagesNavigation();
+  // Fetch previous and next image details
+  const { data: previousImageData } = useQuery(imageQuery, {
+    variables: { id: previousImageId },
+    skip: previousImageId == null,
+  });
+  const { data: nextImageData } = useQuery(imageQuery, {
+    variables: { id: nextImageId },
+    skip: nextImageId == null,
+  });
+  // Fetch previous and next image labels
+  useQuery(getImageLabelsQuery, {
+    variables: { imageId: previousImageId },
+    skip: previousImageId == null,
+  });
+  useQuery(getImageLabelsQuery, {
+    variables: { imageId: nextImageId },
+    skip: nextImageId == null,
+  });
+  // Fetch previous and next image
+  const previousImageUrl = previousImageData?.image?.url;
+  const nextImageUrl = nextImageData?.image?.url;
+  useEffect(() => {
+    if (previousImageUrl != null) {
+      fetch(previousImageUrl);
+    }
+  }, [previousImageUrl]);
+  useEffect(() => {
+    if (nextImageUrl != null) {
+      fetch(nextImageUrl);
+    }
+  }, [nextImageUrl]);
+};


### PR DESCRIPTION
# Feature

## Work performed

- Prefetch previous and next images when being in the labelling platform
- Fix a bug where the welcome modal would try to create the tutorial dataset even if the user already had one

## Results

The images are properly fetched (there is no loading spinner when navigating from one image to the next one even if the user never visited that image) but this did not solve the glitch problem of images navigation.

## Resolved issues

Closes #188
