### PR TITLE
Fix bug in change class shortcut on azerty keyboards

### DIFF
--- a/typescript/web/src/components/labelling-tool/openlayers-map/edit-label-class.tsx
+++ b/typescript/web/src/components/labelling-tool/openlayers-map/edit-label-class.tsx
@@ -75,9 +75,12 @@ export const EditLabelClass = forwardRef<
     [labelClasses, datasetId]
   );
   useHotkeys(
-    keymap.changeClass.key,
+    "*", // We have to manually check if the input corresponds to a change class key because otherwise on AZERTY keyboards we can't change classes when pressing numbers
     (keyboardEvent) => {
-      if (isOpen) {
+      if (
+        keymap.changeClass.key.split(",").includes(keyboardEvent.key) &&
+        isOpen
+      ) {
         // We do not want to interfere with the class menu shortcuts if this modal is closed
         const digit = Number(keyboardEvent.code[5]);
         const indexOfLabelClass = (digit + 9) % 10;

--- a/typescript/web/src/components/labelling-tool/options-tool-bar/edit-label-class-menu.tsx
+++ b/typescript/web/src/components/labelling-tool/options-tool-bar/edit-label-class-menu.tsx
@@ -151,7 +151,7 @@ export const EditLabelClassMenu = () => {
       }
     },
     {},
-    [labelClasses, onSelectedClassChange]
+    [labelClasses, onSelectedClassChange, isContextMenuOpen, setIsOpen]
   );
 
   return (

--- a/typescript/web/src/components/labelling-tool/options-tool-bar/edit-label-class-menu.tsx
+++ b/typescript/web/src/components/labelling-tool/options-tool-bar/edit-label-class-menu.tsx
@@ -138,9 +138,12 @@ export const EditLabelClassMenu = () => {
     (selectedTool === Tools.SELECTION && selectedLabelId != null);
 
   useHotkeys(
-    keymap.changeClass.key,
+    "*", // We have to manually check if the input corresponds to a change class key because otherwise on AZERTY keyboards we can't change classes when pressing numbers
     (keyboardEvent) => {
-      if (!isContextMenuOpen) {
+      if (
+        keymap.changeClass.key.split(",").includes(keyboardEvent.key) &&
+        !isContextMenuOpen
+      ) {
         // We do not want to interfere with the right click popover shortcuts if it is opened
         const digit = Number(keyboardEvent.code[5]);
         const indexOfLabelClass = (digit + 9) % 10;


### PR DESCRIPTION
# Feature

## Work performed

- Fix bug in change class shortcut on azerty keyboards
- Fix bug in keys listener in edit label class menu that missing a dependency

## Results

This PR makes sure that when pressing a number on AZERTY keyboards (so actually pressing `SHIFT`+ `key`) the class is properly changed.

![change-class](https://user-images.githubusercontent.com/17384901/132850481-82f9e547-6e8a-4b22-9c19-ce9a742484c5.gif)


## Caveats

Instead of adding the two possibilities (class is changed both when pressing `SHIFT`+`key` or just `key`) I decided to implement only the change when pressing properly a number. Otherwise we would have allowed to change classes by pressing `SHIFT`+`key` on non-AZERTY keyboards, which causes interferences with other shortcuts in some keyboards.

For example in a spanish keyboard the slash is made with `SHIFT`+`7`, so when pressing that key we would not know if the user wants to set the class corresponding to shortcut 7 or if he wants to use the `/` shortcut to focus the input field.

We could add a detector of keyboard and only allow to change classes by pressing `key` or SHIFT+`key` on AZERTY keyboards but I think it adds complexity for something that might not be worth it.

## Resolved issues

Closes #380 
