### PR TITLE
Fix bug of errors being thrown in service worker from create dataset modal

### DIFF
--- a/data/__generated__/schema.graphql
+++ b/data/__generated__/schema.graphql
@@ -293,6 +293,7 @@ type Query {
   labels(where: LabelWhereInput, first: Int, skip: Int): [Label!]!
   dataset(where: DatasetWhereUniqueInput!): Dataset!
   datasets(where: DatasetWhereInput, first: Int, skip: Int): [Dataset!]!
+  searchDataset(where: DatasetWhereUniqueInput!): Dataset
   workspace(where: WorkspaceWhereUniqueInput!): Workspace!
   workspaces(first: Int, skip: Int): [Workspace!]!
   membership(where: MembershipWhereUniqueInput!): Membership!

--- a/data/queries.graphql
+++ b/data/queries.graphql
@@ -27,6 +27,7 @@ type Query {
 
   dataset(where: DatasetWhereUniqueInput!): Dataset!
   datasets(where: DatasetWhereInput, first: Int, skip: Int): [Dataset!]!
+  searchDataset(where: DatasetWhereUniqueInput!): Dataset
 
   workspace(where: WorkspaceWhereUniqueInput!): Workspace!
   workspaces(first: Int, skip: Int): [Workspace!]!
@@ -37,10 +38,11 @@ type Query {
   user(where: UserWhereUniqueInput!): User!
   users(first: Int, skip: Int): [User!]!
 
-  exportDataset(where: ExportWhereUniqueInput!, 
-                format: ExportFormat!, 
-                options: ExportOptions
-                ): String!
+  exportDataset(
+    where: ExportWhereUniqueInput!
+    format: ExportFormat!
+    options: ExportOptions
+  ): String!
 
   debug: JSON!
 }

--- a/typescript/common-resolvers/src/dataset.ts
+++ b/typescript/common-resolvers/src/dataset.ts
@@ -39,6 +39,17 @@ const getDataset = async (
   return { ...datasetFromRepository, __typename: "Dataset" };
 };
 
+const searchDataset = async (
+  _: any,
+  args: QueryDatasetArgs,
+  { repository }: Context
+): Promise<(DbDataset & { __typename: string }) | undefined> => {
+  const datasetFromRepository = await repository.dataset.get(args.where);
+  return datasetFromRepository != null
+    ? { ...datasetFromRepository, __typename: "Dataset" }
+    : undefined;
+};
+
 // Queries
 const images = async (
   dataset: DbDataset,
@@ -252,6 +263,7 @@ export default {
   Query: {
     dataset,
     datasets,
+    searchDataset,
   },
 
   Mutation: {

--- a/typescript/common-resolvers/src/image.ts
+++ b/typescript/common-resolvers/src/image.ts
@@ -220,8 +220,6 @@ const imagesAggregates = (parent: any) => {
 const totalCount = async (parent: any, _args: any, { repository }: Context) => {
   // eslint-disable-next-line no-underscore-dangle
   const typename = parent?.__typename;
-
-  console.log("parent.id", typename, parent.id);
   if (typename === "Dataset") {
     return await repository.image.count({
       datasetId: parent.id,

--- a/typescript/graphql-types/src/graphql-types.generated.ts
+++ b/typescript/graphql-types/src/graphql-types.generated.ts
@@ -429,6 +429,7 @@ export type Query = {
   labels: Array<Label>;
   dataset: Dataset;
   datasets: Array<Dataset>;
+  searchDataset?: Maybe<Dataset>;
   workspace: Workspace;
   workspaces: Array<Workspace>;
   membership: Membership;
@@ -498,6 +499,11 @@ export type QueryDatasetsArgs = {
   where?: Maybe<DatasetWhereInput>;
   first?: Maybe<Scalars['Int']>;
   skip?: Maybe<Scalars['Int']>;
+};
+
+
+export type QuerySearchDatasetArgs = {
+  where: DatasetWhereUniqueInput;
 };
 
 
@@ -980,6 +986,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   labels?: Resolver<Array<ResolversTypes['Label']>, ParentType, ContextType, RequireFields<QueryLabelsArgs, never>>;
   dataset?: Resolver<ResolversTypes['Dataset'], ParentType, ContextType, RequireFields<QueryDatasetArgs, 'where'>>;
   datasets?: Resolver<Array<ResolversTypes['Dataset']>, ParentType, ContextType, RequireFields<QueryDatasetsArgs, never>>;
+  searchDataset?: Resolver<Maybe<ResolversTypes['Dataset']>, ParentType, ContextType, RequireFields<QuerySearchDatasetArgs, 'where'>>;
   workspace?: Resolver<ResolversTypes['Workspace'], ParentType, ContextType, RequireFields<QueryWorkspaceArgs, 'where'>>;
   workspaces?: Resolver<Array<ResolversTypes['Workspace']>, ParentType, ContextType, RequireFields<QueryWorkspacesArgs, never>>;
   membership?: Resolver<ResolversTypes['Membership'], ParentType, ContextType, RequireFields<QueryMembershipArgs, 'where'>>;

--- a/typescript/web/src/components/datasets/delete-dataset-modal.tsx
+++ b/typescript/web/src/components/datasets/delete-dataset-modal.tsx
@@ -38,6 +38,7 @@ export const DeleteDatasetModal = ({
   const cancelRef = useRef<HTMLButtonElement>(null);
   const { data } = useQuery(getDatasetByIdQuery, {
     variables: { id: datasetId },
+    skip: datasetId == null,
   });
 
   const [deleteDatasetMutate, { loading }] = useMutation(

--- a/typescript/web/src/components/datasets/upsert-dataset-modal.tsx
+++ b/typescript/web/src/components/datasets/upsert-dataset-modal.tsx
@@ -39,7 +39,9 @@ const updateDatasetMutation = gql`
 
 const getDatasetBySlugQuery = gql`
   query getDatasetBySlug($slug: String!) {
-    dataset(where: { slugs: { datasetSlug: $slug, workspaceSlug: "local" } }) {
+    searchDataset(
+      where: { slugs: { datasetSlug: $slug, workspaceSlug: "local" } }
+    ) {
       id
       slug
     }
@@ -136,7 +138,7 @@ export const UpsertDatasetModal = ({
     if (
       existingDataset != null &&
       !loadingExistingDatasets &&
-      existingDataset?.dataset?.id !== datasetId &&
+      existingDataset?.searchDataset?.id !== datasetId &&
       variablesExistingDatasets?.slug === slugify(datasetName, { lower: true })
     ) {
       setErrorMessage("This name is already taken");


### PR DESCRIPTION
# Feature

## Work performed

- Add a query called `searchDataset` that allows to return `null` or `undefined` when querying a dataset that does not exist
- Call this query instead of the normal `dataset` query in `typescript/web/src/components/datasets/upsert-dataset-modal.tsx`
- Skip the `getDatasetByIdQuery` in `typescript/web/src/components/datasets/delete-dataset-modal.tsx` when `datasetId` is not defined to avoid throwing another error

## Results

No more errors are being thrown from the backend when creating a dataset

## Resolved issues

Closes #436 
