### PR TITLE
Fix bug of error being thrown when clearing site data and reloading page

### DIFF
--- a/typescript/common-resolvers/src/dataset.ts
+++ b/typescript/common-resolvers/src/dataset.ts
@@ -33,7 +33,7 @@ const getDataset = async (
   const datasetFromRepository = await repository.dataset.get(where);
   if (datasetFromRepository == null) {
     throw new Error(
-      `Couldn't find this dataset corresponding to ${JSON.stringify(where)}`
+      `Couldn't find dataset corresponding to ${JSON.stringify(where)}`
     );
   }
   return { ...datasetFromRepository, __typename: "Dataset" };

--- a/typescript/web/src/components/datasets/__tests__/delete-dataset-modal.tsx
+++ b/typescript/web/src/components/datasets/__tests__/delete-dataset-modal.tsx
@@ -57,7 +57,7 @@ test("should delete a dataset when the button is clicked", async () => {
       variables: { id: mutateResult.data.createDataset.id },
       fetchPolicy: "no-cache",
     })
-  ).rejects.toThrow(/Couldn't find this dataset corresponding to/);
+  ).rejects.toThrow(/Couldn't find dataset corresponding to/);
 });
 
 test("shouldn't delete a dataset when the cancel is clicked", async () => {

--- a/typescript/web/src/connectors/resolvers/__tests__/dataset.ts
+++ b/typescript/web/src/connectors/resolvers/__tests__/dataset.ts
@@ -203,7 +203,7 @@ describe("Dataset resolver test suite", () => {
           id: "a id that doesn't exist",
         },
       })
-    ).rejects.toThrow(/Couldn't find this dataset corresponding to/);
+    ).rejects.toThrow(/Couldn't find dataset corresponding to/);
   });
 
   test("Read multiple datasets", async () => {
@@ -378,7 +378,7 @@ describe("Dataset resolver test suite", () => {
           id: datasetId,
         },
       })
-    ).rejects.toThrow(/Couldn't find this dataset corresponding to/);
+    ).rejects.toThrow(/Couldn't find dataset corresponding to/);
   });
 
   test("should throw an error if the dataset to delete does not exist", () => {
@@ -396,7 +396,7 @@ describe("Dataset resolver test suite", () => {
           id: "not existing dataset id",
         },
       })
-    ).rejects.toThrow(/Couldn't find this dataset corresponding to/);
+    ).rejects.toThrow(/Couldn't find dataset corresponding to/);
   });
 
   test("Should update a dataset with a new name", async () => {
@@ -522,7 +522,7 @@ describe("Dataset resolver test suite", () => {
           data: { name: "My new dataset new name" },
         },
       })
-    ).rejects.toThrow(/Couldn't find this dataset corresponding to/);
+    ).rejects.toThrow(/Couldn't find dataset corresponding to/);
   });
 
   test("Find dataset by name", async () => {

--- a/typescript/web/src/pages/local/datasets/[datasetSlug]/classes/index.tsx
+++ b/typescript/web/src/pages/local/datasets/[datasetSlug]/classes/index.tsx
@@ -47,7 +47,7 @@ const DatasetClassesPage = () => {
 
   const handleError = useErrorHandler();
   if (error && !loading) {
-    if (!error.message.match(/No dataset with slug/)) {
+    if (!error.message.match(/Couldn't find dataset corresponding to/)) {
       handleError(error);
     }
     return (

--- a/typescript/web/src/pages/local/datasets/[datasetSlug]/images/[imageId].tsx
+++ b/typescript/web/src/pages/local/datasets/[datasetSlug]/images/[imageId].tsx
@@ -96,7 +96,9 @@ const ImagePage = () => {
   const handleError = useErrorHandler();
   if ((errorDataset && !loadingDataset) || (errorImage && !loadingImage)) {
     if (errorDataset && !loadingDataset) {
-      if (!errorDataset.message.match(/No dataset with slug/)) {
+      if (
+        !errorDataset.message.match(/Couldn't find dataset corresponding to/)
+      ) {
         handleError(errorDataset);
       }
       return (

--- a/typescript/web/src/pages/local/datasets/[datasetSlug]/images/index.tsx
+++ b/typescript/web/src/pages/local/datasets/[datasetSlug]/images/index.tsx
@@ -68,7 +68,7 @@ const ImagesPage = () => {
 
   const handleError = useErrorHandler();
   if (error && !loading) {
-    if (!error.message.match(/No dataset with slug/)) {
+    if (!error.message.match(/Couldn't find dataset corresponding to/)) {
       handleError(error);
     }
     return (

--- a/typescript/web/src/pages/local/datasets/[datasetSlug]/index.tsx
+++ b/typescript/web/src/pages/local/datasets/[datasetSlug]/index.tsx
@@ -56,7 +56,7 @@ const DatasetIndexPage = () => {
 
   const handleError = useErrorHandler();
   if (error && !loading) {
-    if (!error.message.match(/No dataset with slug/)) {
+    if (!error.message.match(/Couldn't find dataset corresponding to/)) {
       handleError(error);
     }
     return (


### PR DESCRIPTION
# Feature

## Work performed

- Fix bug of error being thrown when clearing site data and reloading page

## Results

Before when clearing site data on a page of type `[datasetSlug]/images/[imageId]` this error would be thrown:
<img width="1680" alt="Screenshot 2021-09-17 at 18 01 48" src="https://user-images.githubusercontent.com/17384901/133819200-b1888bfd-e286-4b70-8e31-b3498908136c.png">

Now with this PR the error is properly handled:
![no-error](https://user-images.githubusercontent.com/17384901/133819540-ca7eb118-d2ef-4725-a2bb-c5966ce22650.gif)


## Problems encountered

<!--- Explain problems that were encountered when implementing this MR -->

## Caveats

<!--- Any particular attention point with what you did? -->

## Resolved issues

<!--- List references to issues that this PR resolves -->

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
