### PR TITLE
Feature/#227 import coco

### DIFF
--- a/data/__generated__/schema.graphql
+++ b/data/__generated__/schema.graphql
@@ -139,6 +139,10 @@ type ImagesAggregates {
   totalCount: Int!
 }
 
+type ImportStatus {
+  error: String
+}
+
 scalar JSON
 
 type Label {
@@ -270,6 +274,7 @@ type Mutation {
   createDemoDataset: Dataset
   updateDataset(where: DatasetWhereUniqueInput!, data: DatasetUpdateInput!): Dataset
   deleteDataset(where: DatasetWhereUniqueInput!): Dataset
+  importDataset(url: String!, format: ExportFormat!): ImportStatus
   createWorkspace(data: WorkspaceCreateInput!): Workspace
   updateWorkspace(where: WorkspaceWhereUniqueInput!, data: WorkspaceUpdateInput!): Workspace
   createMembership(data: MembershipCreateInput!): Membership

--- a/data/__generated__/schema.graphql
+++ b/data/__generated__/schema.graphql
@@ -24,6 +24,7 @@ input DatasetCreateInput {
 input DatasetImportInput {
   url: String!
   format: ExportFormat!
+  options: ImportOptions
 }
 
 input DatasetUpdateInput {
@@ -142,6 +143,14 @@ input ImageWhereUniqueInput {
 
 type ImagesAggregates {
   totalCount: Int!
+}
+
+input ImportOptions {
+  coco: ImportOptionsCoco
+}
+
+input ImportOptionsCoco {
+  annotationsOnly: Boolean
 }
 
 type ImportStatus {

--- a/data/__generated__/schema.graphql
+++ b/data/__generated__/schema.graphql
@@ -178,7 +178,7 @@ type LabelClass {
 input LabelClassCreateInput {
   id: ID
   name: String!
-  color: ColorHex!
+  color: ColorHex
   datasetId: ID!
 }
 

--- a/data/__generated__/schema.graphql
+++ b/data/__generated__/schema.graphql
@@ -21,6 +21,11 @@ input DatasetCreateInput {
   workspaceSlug: String!
 }
 
+input DatasetImportInput {
+  url: String!
+  format: ExportFormat!
+}
+
 input DatasetUpdateInput {
   name: String!
 }
@@ -274,7 +279,7 @@ type Mutation {
   createDemoDataset: Dataset
   updateDataset(where: DatasetWhereUniqueInput!, data: DatasetUpdateInput!): Dataset
   deleteDataset(where: DatasetWhereUniqueInput!): Dataset
-  importDataset(url: String!, format: ExportFormat!): ImportStatus
+  importDataset(where: DatasetWhereUniqueInput!, data: DatasetImportInput!): ImportStatus
   createWorkspace(data: WorkspaceCreateInput!): Workspace
   updateWorkspace(where: WorkspaceWhereUniqueInput!, data: WorkspaceUpdateInput!): Workspace
   createMembership(data: MembershipCreateInput!): Membership

--- a/data/import.graphql
+++ b/data/import.graphql
@@ -2,7 +2,16 @@ type ImportStatus{
     error: String
 }
 
+input ImportOptionsCoco {
+    annotationsOnly: Boolean
+}
+
+input ImportOptions {
+    coco: ImportOptionsCoco
+}
+
 input DatasetImportInput{
     url: String!
     format: ExportFormat!
+    options: ImportOptions
 }

--- a/data/import.graphql
+++ b/data/import.graphql
@@ -1,3 +1,8 @@
 type ImportStatus{
     error: String
 }
+
+input DatasetImportInput{
+    url: String!
+    format: ExportFormat!
+}

--- a/data/import.graphql
+++ b/data/import.graphql
@@ -1,0 +1,3 @@
+type ImportStatus{
+    error: String
+}

--- a/data/label-class.graphql
+++ b/data/label-class.graphql
@@ -1,7 +1,7 @@
 input LabelClassCreateInput {
   id: ID
   name: String!
-  color: ColorHex!
+  color: ColorHex
   datasetId: ID!
 }
 

--- a/data/mutations.graphql
+++ b/data/mutations.graphql
@@ -27,6 +27,11 @@ type Mutation {
   ): Dataset
   deleteDataset(where: DatasetWhereUniqueInput!): Dataset
 
+  importDataset(
+    url: String!
+    format: ExportFormat!
+  ): ImportStatus
+
   createWorkspace(data: WorkspaceCreateInput!): Workspace
   updateWorkspace(
     where: WorkspaceWhereUniqueInput!

--- a/data/mutations.graphql
+++ b/data/mutations.graphql
@@ -28,8 +28,8 @@ type Mutation {
   deleteDataset(where: DatasetWhereUniqueInput!): Dataset
 
   importDataset(
-    url: String!
-    format: ExportFormat!
+    where: DatasetWhereUniqueInput!
+    data: DatasetImportInput!
   ): ImportStatus
 
   createWorkspace(data: WorkspaceCreateInput!): Workspace

--- a/typescript/common-resolvers/src/export/format-coco/coco-core/__tests__/converters.ts
+++ b/typescript/common-resolvers/src/export/format-coco/coco-core/__tests__/converters.ts
@@ -35,7 +35,7 @@ describe("Coco converters", () => {
   const createLabelWithImageDimensions = (
     id: string,
     imageId: string,
-    labelClassId?: string
+    labelClassId: string = "someLabelClassId"
   ): DbLabelWithImageDimensions => ({
     id,
     createdAt: date,
@@ -127,12 +127,12 @@ describe("Coco converters", () => {
   test("Should convert a label to a coco annotation without category", () => {
     const label = createLabelWithImageDimensions("a-label-id", "an-image-id");
 
-    const cocoAnnotation = convertLabelToCocoAnnotation(label, 1, 42, null);
+    const cocoAnnotation = convertLabelToCocoAnnotation(label, 1, 42, 0);
 
     const expectedAnnotation: CocoAnnotation = {
       id: 1,
       image_id: 42,
-      category_id: null,
+      category_id: 0,
       segmentation: [[1, 198, 1, 194, 4, 194, 4, 198, 1, 198]],
       area: 12,
       bbox: [1, 194, 3, 4],

--- a/typescript/common-resolvers/src/export/format-coco/coco-core/converters.ts
+++ b/typescript/common-resolvers/src/export/format-coco/coco-core/converters.ts
@@ -117,7 +117,7 @@ const convertLabelToCocoAnnotation = (
   }: DbLabelWithImageDimensions,
   id: number,
   imageId: number,
-  categoryId: number | null = null
+  categoryId: number
 ): CocoAnnotation => {
   return {
     id,
@@ -144,7 +144,7 @@ const convertLabelsOfImageToCocoAnnotations = (
       label,
       cocoAnnotationId,
       imageIdsMap[label.imageId],
-      label.labelClassId ? labelClassIdsMap[label.labelClassId] : null
+      labelClassIdsMap[label.labelClassId],
     );
   });
 };

--- a/typescript/common-resolvers/src/export/format-coco/coco-core/types.ts
+++ b/typescript/common-resolvers/src/export/format-coco/coco-core/types.ts
@@ -25,7 +25,7 @@ type Polygon = number[];
 export type CocoAnnotation = {
   id: number;
   image_id: number;
-  category_id: number | null;
+  category_id: number;
   segmentation: Polygon[];
   area: number;
   bbox: [x: number, y: number, width: number, height: number];
@@ -51,7 +51,7 @@ export type CocoDataset = {
   annotations: CocoAnnotation[];
 };
 
-export type CacheLabelClassIdToCocoCategoryId = Map<string | undefined, number>;
+export type CacheLabelClassIdToCocoCategoryId = Map<string, number>;
 
 export type DbLabelWithImageDimensions = DbLabel & {
   imageDimensions: { width: number; height: number };

--- a/typescript/common-resolvers/src/export/format-coco/coco-core/types.ts
+++ b/typescript/common-resolvers/src/export/format-coco/coco-core/types.ts
@@ -53,6 +53,8 @@ export type CocoDataset = {
 
 export type CacheLabelClassIdToCocoCategoryId = Map<string, number>;
 
-export type DbLabelWithImageDimensions = Omit<DbLabel, "labelClassId"> & {labelClassId: string;} & {
+export type DbLabelWithImageDimensions = Omit<DbLabel, "labelClassId"> & {
+  labelClassId: string;
+} & {
   imageDimensions: { width: number; height: number };
 };

--- a/typescript/common-resolvers/src/export/format-coco/coco-core/types.ts
+++ b/typescript/common-resolvers/src/export/format-coco/coco-core/types.ts
@@ -53,8 +53,13 @@ export type CocoDataset = {
 
 export type CacheLabelClassIdToCocoCategoryId = Map<string, number>;
 
-export type DbLabelWithImageDimensions = Omit<DbLabel, "labelClassId"> & {
-  labelClassId: string;
-} & {
+export type DbLabelWithImageDimensions = DbLabel & {
   imageDimensions: { width: number; height: number };
+};
+
+export type DbLabelWithImageDimensionsAndLabelClass = Omit<
+  DbLabelWithImageDimensions,
+  "labelClassId"
+> & {
+  labelClassId: string;
 };

--- a/typescript/common-resolvers/src/export/format-coco/coco-core/types.ts
+++ b/typescript/common-resolvers/src/export/format-coco/coco-core/types.ts
@@ -53,6 +53,6 @@ export type CocoDataset = {
 
 export type CacheLabelClassIdToCocoCategoryId = Map<string, number>;
 
-export type DbLabelWithImageDimensions = DbLabel & {
+export type DbLabelWithImageDimensions = Omit<DbLabel, "labelClassId"> & {labelClassId: string;} & {
   imageDimensions: { width: number; height: number };
 };

--- a/typescript/common-resolvers/src/import/format-coco/__tests__/__snapshots__/converters.ts.snap
+++ b/typescript/common-resolvers/src/import/format-coco/__tests__/__snapshots__/converters.ts.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`convertCocoSegmentationToLabel Should convert a box into a box 1`] = `
+Object {
+  "geometry": Object {
+    "coordinates": Array [
+      Array [
+        Array [
+          123.33,
+          313.9999,
+        ],
+        Array [
+          369.12346,
+          313.9995,
+        ],
+        Array [
+          369.12348,
+          0.9056399999999485,
+        ],
+        Array [
+          123.33,
+          0.9054399999999987,
+        ],
+        Array [
+          123.33,
+          313.9999,
+        ],
+      ],
+    ],
+    "type": "Polygon",
+  },
+  "type": "Box",
+}
+`;
+
+exports[`convertCocoSegmentationToLabel Should convert a polygon into a box 1`] = `
+Object {
+  "geometry": Object {
+    "coordinates": Array [
+      Array [
+        Array [
+          123.33,
+          313.9999,
+        ],
+        Array [
+          369.12346,
+          313.9995,
+        ],
+        Array [
+          369.12348,
+          0.9056399999999485,
+        ],
+        Array [
+          123.33,
+          0.9054399999999987,
+        ],
+        Array [
+          100,
+          18,
+        ],
+        Array [
+          123.33,
+          313.9999,
+        ],
+      ],
+    ],
+    "type": "Polygon",
+  },
+  "type": "Polygon",
+}
+`;

--- a/typescript/common-resolvers/src/import/format-coco/__tests__/__snapshots__/converters.ts.snap
+++ b/typescript/common-resolvers/src/import/format-coco/__tests__/__snapshots__/converters.ts.snap
@@ -33,7 +33,7 @@ Object {
 }
 `;
 
-exports[`convertCocoSegmentationToLabel Should convert a polygon into a box 1`] = `
+exports[`convertCocoSegmentationToLabel Should convert a polygon into a polygon 1`] = `
 Object {
   "geometry": Object {
     "coordinates": Array [

--- a/typescript/common-resolvers/src/import/format-coco/__tests__/converters.ts
+++ b/typescript/common-resolvers/src/import/format-coco/__tests__/converters.ts
@@ -1,0 +1,87 @@
+import {
+  isCocoSegmentationBox,
+  convertCocoSegmentationToLabel,
+} from "../converters";
+
+describe("isCocoSegmentationBox", () => {
+  test("Should spot segmentation box", () => {
+    expect(
+      isCocoSegmentationBox([
+        [
+          123.33, 254.0001, 369.12346, 254.0005, 369.12348, 567.09436, 123.33,
+          567.09456, 123.33, 254.0001,
+        ],
+      ])
+    ).toBeTruthy();
+  });
+  test("Should discard segmentation with more than one polygon", () => {
+    expect(
+      isCocoSegmentationBox([
+        [
+          123.33, 254.0001, 369.12346, 254.0005, 369.12348, 567.09436, 123.33,
+          567.09456, 123.33, 254.0001,
+        ],
+        [100, 0],
+      ])
+    ).toBeFalsy();
+  });
+  test("Should discard segmentation with more than ten coordinates", () => {
+    expect(
+      isCocoSegmentationBox([
+        [
+          123.33, 254.0001, 369.12346, 254.0005, 369.12348, 567.09436, 123.33,
+          567.09456, 123.33, 254.0001, 100, 0,
+        ],
+      ])
+    ).toBeFalsy();
+  });
+  test("Should discard reordered segmentation of a box", () => {
+    expect(
+      isCocoSegmentationBox([
+        [
+          123.33, 254.0001, 369.12346, 254.0005, 369.12348, 567.09436, 123.33,
+          567.09456, 254.0001, 123.33,
+        ],
+      ])
+    ).toBeFalsy();
+  });
+  test("Should discard degenerated box (reordered points)", () => {
+    expect(
+      isCocoSegmentationBox([
+        [
+          123.33, 254.0001, 369.12348, 567.09436, 369.12346, 254.0005, 123.33,
+          567.09456, 123.33, 254.0001,
+        ],
+      ])
+    ).toBeFalsy();
+  });
+});
+
+describe("convertCocoSegmentationToLabel", () => {
+  test("Should convert a box into a box", () => {
+    expect(
+      convertCocoSegmentationToLabel(
+        [
+          [
+            123.33, 254.0001, 369.12346, 254.0005, 369.12348, 567.09436, 123.33,
+            567.09456, 123.33, 254.0001,
+          ],
+        ],
+        568
+      )
+    ).toMatchSnapshot();
+  });
+  test("Should convert a polygon into a polygon", () => {
+    expect(
+      convertCocoSegmentationToLabel(
+        [
+          [
+            123.33, 254.0001, 369.12346, 254.0005, 369.12348, 567.09436, 123.33,
+            567.09456, 100, 550, 123.33, 254.0001,
+          ],
+        ],
+        568
+      )
+    ).toMatchSnapshot();
+  });
+});

--- a/typescript/common-resolvers/src/import/format-coco/converters.ts
+++ b/typescript/common-resolvers/src/import/format-coco/converters.ts
@@ -1,0 +1,69 @@
+import type { GeometryInput, LabelType } from "@labelflow/graphql-types";
+import { LabelType as LabelTypeOptions } from "@labelflow/graphql-types";
+
+import { range } from "lodash/fp";
+
+export const isCocoSegmentationBox = (
+  cocoSegmentation: number[][]
+): boolean => {
+  if (cocoSegmentation.length === 0) {
+    throw new Error("received segmentation without any items inside.");
+  }
+  if (cocoSegmentation.length > 1 || cocoSegmentation[0].length !== 10) {
+    return false;
+  }
+  const maybeBox = cocoSegmentation[0].map(Math.floor);
+  const { x: xValues, y: yValues } = maybeBox.reduce(
+    ({ x, y }, value, index) => {
+      if (index % 2 === 0) {
+        x.add(value);
+      } else {
+        y.add(value);
+      }
+      return { x, y };
+    },
+    { x: new Set(), y: new Set() }
+  );
+  const { isDegenerate: polygonIsDegenerate } = range(
+    0,
+    maybeBox.length / 2 - 2
+  ).reduce(
+    ({ isDegenerate, crossProductSign }, index) => {
+      if (isDegenerate) {
+        return { isDegenerate, crossProductSign };
+      }
+      const xA = maybeBox[2 * index + 2] - maybeBox[2 * index];
+      const yA = maybeBox[2 * index + 3] - maybeBox[2 * index + 1];
+      const xB = maybeBox[2 * index + 4] - maybeBox[2 * index + 2];
+      const yB = maybeBox[2 * index + 5] - maybeBox[2 * index + 3];
+      const currentCrossProductSign = Math.sign(xA * yB - xB * yA);
+      if (crossProductSign && crossProductSign !== currentCrossProductSign) {
+        return { crossProductSign: 0, isDegenerate: true };
+      }
+      return {
+        crossProductSign: currentCrossProductSign,
+        isDegenerate: false,
+      };
+    },
+    { isDegenerate: false, crossProductSign: 0 }
+  );
+  return xValues.size === 2 && yValues.size === 2 && !polygonIsDegenerate;
+};
+
+export const convertCocoSegmentationToLabel = (
+  cocoSegmentation: number[][],
+  imageHeight: number
+): { geometry: GeometryInput; type: LabelType } => ({
+  type: isCocoSegmentationBox(cocoSegmentation)
+    ? LabelTypeOptions.Box
+    : LabelTypeOptions.Polygon,
+  geometry: {
+    type: "Polygon",
+    coordinates: cocoSegmentation.map((cocoPolygon) =>
+      range(0, cocoPolygon.length / 2).map((index) => [
+        cocoPolygon[2 * index],
+        imageHeight - cocoPolygon[2 * index + 1],
+      ])
+    ),
+  },
+});

--- a/typescript/common-resolvers/src/import/format-coco/index.ts
+++ b/typescript/common-resolvers/src/import/format-coco/index.ts
@@ -115,26 +115,19 @@ export const importCoco: ImportFunction = async (
     );
     // Manage coco images => labelflow images
     const images = await repository.image.list({ datasetId });
-    const imagesCoco = annotationFile.images.filter((imageCoco) => {
-      const labelFlowImage = images.find(
-        (image) =>
-          image.name ===
-          imageCoco.file_name.replace(path.extname(imageCoco.file_name), "")
-      );
-      if (labelFlowImage) {
-        // cocoImageIdToLabelFlowImageId.set(imageCoco.id, labelFlowImage.id);
-        return false;
-      }
-      return true;
-    });
+    const imagesCoco = annotationFile.images.filter(
+      (imageCoco) =>
+        !images.find(
+          (image) =>
+            image.name ===
+            imageCoco.file_name.replace(path.extname(imageCoco.file_name), "")
+        )
+    );
     // eslint-disable-next-line no-restricted-syntax
     for (const imageCoco of imagesCoco) {
       const imageFile = imageNameToFile.get(imageCoco.file_name);
       // eslint-disable-next-line no-await-in-loop
-      const {
-        id: labelFlowImageId,
-        // eslint-disable-next-line no-await-in-loop
-      } = await uploadImage(imageFile, imageCoco.file_name, datasetId, {
+      await uploadImage(imageFile, imageCoco.file_name, datasetId, {
         repository,
       });
       // cocoImageIdToLabelFlowImageId.set(imageCoco.id, labelFlowImageId);

--- a/typescript/common-resolvers/src/import/format-coco/index.ts
+++ b/typescript/common-resolvers/src/import/format-coco/index.ts
@@ -1,37 +1,73 @@
 import JSZip from "jszip";
+import path from "path";
 import { v4 as uuidv4 } from "uuid";
 
 import type { UploadTargetHttp } from "@labelflow/graphql-types";
 
 import { ImportFunction } from "../types";
+import imageResolvers from "../../image";
+import { CocoDataset } from "../../export/format-coco/coco-core/types";
 
-export const importCoco: ImportFunction = async (zipBlob, { repository }) => {
+const uploadImage = async (file, name, datasetId, { repository }) => {
+  const fileBlob = await file.async("blob", () => {});
+  const uploadTarget = await repository.upload.getUploadTarget(uuidv4());
+  if (!(uploadTarget as UploadTargetHttp)?.downloadUrl) {
+    throw new Error("Can't direct upload this image.");
+  }
+  repository.upload.put(
+    (uploadTarget as UploadTargetHttp)?.downloadUrl,
+    fileBlob
+  );
+  await imageResolvers.Mutation.createImage(
+    null,
+    {
+      data: {
+        url: (uploadTarget as UploadTargetHttp)?.downloadUrl,
+        name,
+        datasetId,
+      },
+    },
+    { repository }
+  );
+  console.log("uploaded image ", name);
+};
+
+export const importCoco: ImportFunction = async (
+  zipBlob,
+  datasetId,
+  { repository }
+) => {
   const zip = await JSZip.loadAsync(zipBlob);
-  const annotationsFilePath = "";
-  zip.forEach(async (relativePath, file) => {
-    const fileBlob = await file.async("blob", () => {});
-    if (relativePath.split("/").includes("images")) {
-      const uploadTarget = await repository.upload.getUploadTarget(uuidv4());
-      if (!(uploadTarget as UploadTargetHttp)?.downloadUrl) {
-        throw new Error("Can't direct upload this image.");
-      }
-      repository.upload.put(
-        (uploadTarget as UploadTargetHttp)?.downloadUrl,
-        fileBlob
-      );
-      console.log("uploaded image ", relativePath);
-    } else {
-      const pathSplitExtension = relativePath.split(".");
-      if (!(pathSplitExtension[pathSplitExtension.length - 1] === "json")) {
-        throw new Error(`Received an unknown file: ${relativePath}`);
-      }
-      if (annotationsFilePath) {
-        throw new Error(
-          `Already received an annotation file ${annotationsFilePath} and found another json file named ${relativePath}`
-        );
-      }
-      // Supposed to implement the import of that file now
-    }
-  });
-  // Do sthg
+  const annotationsFilesJSZip = zip.filter(
+    (relativePath) => path.extname(relativePath) === ".json"
+  );
+  if (annotationsFilesJSZip.length === 0) {
+    throw new Error("No COCO annotation file was found in the zip file.");
+  }
+  if (annotationsFilesJSZip.length > 1) {
+    throw new Error(
+      "More than one COCO annotation file was found in the zip file."
+    );
+  }
+  const annotationFile: CocoDataset = JSON.parse(
+    await annotationsFilesJSZip[0].async("string", () => {})
+  );
+  //   console.log(JSON.stringify(annotationFile, null, 1));
+  const imageFiles = zip.filter((relativePath) =>
+    path.dirname(relativePath).endsWith("images")
+  );
+  const imageNameToFile = imageFiles.reduce(
+    (imageNameToFileCurrent, imageFile) => {
+      imageNameToFileCurrent.set(path.basename(imageFile.name), imageFile);
+      return imageNameToFileCurrent;
+    },
+    new Map()
+  );
+  const { images } = annotationFile;
+  // eslint-disable-next-line no-restricted-syntax
+  for (const image of images) {
+    const imageFile = imageNameToFile.get(image.file_name);
+    // eslint-disable-next-line no-await-in-loop
+    await uploadImage(imageFile, image.file_name, datasetId, { repository });
+  }
 };

--- a/typescript/common-resolvers/src/import/format-coco/index.ts
+++ b/typescript/common-resolvers/src/import/format-coco/index.ts
@@ -145,30 +145,32 @@ export const importCoco: ImportFunction = async (
     console.log(`Created category ${categoryCoco.name}`);
   }
   // Manage coco annotations => labelflow labels
-  await annotationFile.annotations.map(async (annotation) => {
-    if (!cocoImageIdToLabelFlowImageId.has(annotation.image_id)) {
-      throw new Error(
-        `Image ${annotation.image_id} referenced in annotation does not exist.`
-      );
-    }
-    await labelResolvers.Mutation.createLabel(
-      null,
-      {
-        data: {
-          imageId: cocoImageIdToLabelFlowImageId.get(
-            annotation.image_id
-          ) as string,
-          labelClassId: cocoCategoryIdToLabelFlowLabelClassId.get(
-            annotation.category_id
-          ),
-          ...convertCocoSegmentationToLabel(
-            annotation.segmentation,
-            annotationFile.images[annotation.image_id - 1].height
-          ),
+  await Promise.all(
+    annotationFile.annotations.map(async (annotation) => {
+      if (!cocoImageIdToLabelFlowImageId.has(annotation.image_id)) {
+        throw new Error(
+          `Image ${annotation.image_id} referenced in annotation does not exist.`
+        );
+      }
+      await labelResolvers.Mutation.createLabel(
+        null,
+        {
+          data: {
+            imageId: cocoImageIdToLabelFlowImageId.get(
+              annotation.image_id
+            ) as string,
+            labelClassId: cocoCategoryIdToLabelFlowLabelClassId.get(
+              annotation.category_id
+            ),
+            ...convertCocoSegmentationToLabel(
+              annotation.segmentation,
+              annotationFile.images[annotation.image_id - 1].height
+            ),
+          },
         },
-      },
-      { repository }
-    );
-    console.log(`Created annotation ${annotation.id}`);
-  });
+        { repository }
+      );
+      console.log(`Created annotation ${annotation.id}`);
+    })
+  );
 };

--- a/typescript/common-resolvers/src/import/format-coco/index.ts
+++ b/typescript/common-resolvers/src/import/format-coco/index.ts
@@ -2,10 +2,18 @@ import JSZip from "jszip";
 import path from "path";
 import { v4 as uuidv4 } from "uuid";
 
-import type { UploadTargetHttp } from "@labelflow/graphql-types";
+import type {
+  UploadTargetHttp,
+  GeometryInput,
+  LabelType,
+} from "@labelflow/graphql-types";
+import { LabelType as LabelTypeOptions } from "@labelflow/graphql-types";
 
+import { range } from "lodash/fp";
 import { ImportFunction } from "../types";
 import imageResolvers from "../../image";
+import labelClassResolvers from "../../label-class";
+import labelResolvers from "../../label";
 import { CocoDataset } from "../../export/format-coco/coco-core/types";
 
 const uploadImage = async (file, name, datasetId, { repository }) => {
@@ -18,7 +26,7 @@ const uploadImage = async (file, name, datasetId, { repository }) => {
     (uploadTarget as UploadTargetHttp)?.downloadUrl,
     fileBlob
   );
-  await imageResolvers.Mutation.createImage(
+  return await imageResolvers.Mutation.createImage(
     null,
     {
       data: {
@@ -29,8 +37,47 @@ const uploadImage = async (file, name, datasetId, { repository }) => {
     },
     { repository }
   );
-  console.log("uploaded image ", name);
 };
+
+const isCocoSegmentationBox = (cocoSegmentation: number[][]): boolean => {
+  if (cocoSegmentation.length === 0) {
+    throw new Error("received segmentation without any items inside.");
+  }
+  if (cocoSegmentation.length > 1 || cocoSegmentation[0].length !== 10) {
+    return false;
+  }
+  const maybeBox = cocoSegmentation[0].map(Math.floor);
+  const { x: xValues, y: yValues } = maybeBox.reduce(
+    ({ x, y }, value, index) => {
+      if (index % 2 === 0) {
+        x.add(value);
+      } else {
+        y.add(value);
+      }
+      return { x, y };
+    },
+    { x: new Set(), y: new Set() }
+  );
+  return xValues.size === 2 && yValues.size === 2;
+};
+
+const convertCocoSegmentationToLabel = (
+  cocoSegmentation: number[][],
+  imageHeight: number
+): { geometry: GeometryInput; type: LabelType } => ({
+  type: isCocoSegmentationBox(cocoSegmentation)
+    ? LabelTypeOptions.Box
+    : LabelTypeOptions.Polygon,
+  geometry: {
+    type: "Polygon",
+    coordinates: cocoSegmentation.map((cocoPolygon) =>
+      range(0, cocoPolygon.length / 2).map((index) => [
+        cocoPolygon[2 * index],
+        imageHeight - cocoPolygon[2 * index + 1],
+      ])
+    ),
+  },
+});
 
 export const importCoco: ImportFunction = async (
   zipBlob,
@@ -52,7 +99,6 @@ export const importCoco: ImportFunction = async (
   const annotationFile: CocoDataset = JSON.parse(
     await annotationsFilesJSZip[0].async("string", () => {})
   );
-  //   console.log(JSON.stringify(annotationFile, null, 1));
   const imageFiles = zip.filter((relativePath) =>
     path.dirname(relativePath).endsWith("images")
   );
@@ -63,11 +109,85 @@ export const importCoco: ImportFunction = async (
     },
     new Map()
   );
-  const { images } = annotationFile;
+  // Manage coco images => labelflow images
+  const cocoImageIdToLabelFlowImageId = new Map<number, string>();
+  const images = await repository.image.list({ datasetId });
+  const imagesCoco = annotationFile.images.filter((imageCoco) => {
+    const labelFlowImage = images.find(
+      (image) =>
+        image.name ===
+        imageCoco.file_name.replace(path.extname(imageCoco.file_name), "")
+    );
+    if (labelFlowImage) {
+      cocoImageIdToLabelFlowImageId.set(imageCoco.id, labelFlowImage.id);
+      return false;
+    }
+    return true;
+  });
   // eslint-disable-next-line no-restricted-syntax
-  for (const image of images) {
-    const imageFile = imageNameToFile.get(image.file_name);
+  for (const imageCoco of imagesCoco) {
+    const imageFile = imageNameToFile.get(imageCoco.file_name);
     // eslint-disable-next-line no-await-in-loop
-    await uploadImage(imageFile, image.file_name, datasetId, { repository });
+    const {
+      id: labelFlowImageId,
+      // eslint-disable-next-line no-await-in-loop
+    } = await uploadImage(imageFile, imageCoco.file_name, datasetId, {
+      repository,
+    });
+    cocoImageIdToLabelFlowImageId.set(imageCoco.id, labelFlowImageId);
+    console.log(`Created image ${imageCoco.file_name}`);
   }
+  // Manage coco categories => labelflow labelclasses
+  const cocoCategoryIdToLabelFlowLabelClassId = new Map<number, string>();
+  const labelClasses = await repository.labelClass.list({ datasetId });
+  const categoriesCoco = annotationFile.categories.filter((categoryCoco) => {
+    const labelFlowLabelClass = labelClasses.find(
+      (labelClass) => labelClass.name === categoryCoco.name
+    );
+    if (labelFlowLabelClass) {
+      cocoCategoryIdToLabelFlowLabelClassId.set(
+        categoryCoco.id,
+        labelFlowLabelClass.id
+      );
+      return false;
+    }
+    return true;
+  });
+  // eslint-disable-next-line no-restricted-syntax
+  for (const categoryCoco of categoriesCoco) {
+    const { id: labelFlowLabelClassId } =
+      // eslint-disable-next-line no-await-in-loop
+      await labelClassResolvers.Mutation.createLabelClass(
+        null,
+        {
+          data: { name: categoryCoco.name, datasetId, color: 0xbbbbbb }, // TODO: manage labelClass colors
+        },
+        { repository }
+      );
+    cocoCategoryIdToLabelFlowLabelClassId.set(
+      categoryCoco.id,
+      labelFlowLabelClassId
+    );
+    console.log(`Created category ${categoryCoco.name}`);
+  }
+  // Manage coco annotations => labelflow labels
+  await annotationFile.annotations.map(async (annotation) => {
+    await labelResolvers.Mutation.createLabel(
+      null,
+      {
+        data: {
+          imageId: cocoImageIdToLabelFlowImageId.get(annotation.image_id),
+          labelClassId: cocoCategoryIdToLabelFlowLabelClassId.get(
+            annotation.category_id
+          ),
+          ...convertCocoSegmentationToLabel(
+            annotation.segmentation,
+            annotationFile.images[annotation.image_id - 1].height
+          ),
+        },
+      },
+      { repository }
+    );
+    console.log(`Created annotation ${annotation.id}`);
+  });
 };

--- a/typescript/common-resolvers/src/import/format-coco/index.ts
+++ b/typescript/common-resolvers/src/import/format-coco/index.ts
@@ -160,7 +160,7 @@ export const importCoco: ImportFunction = async (
       await labelClassResolvers.Mutation.createLabelClass(
         null,
         {
-          data: { name: categoryCoco.name, datasetId, color: 0xbbbbbb }, // TODO: manage labelClass colors
+          data: { name: categoryCoco.name, datasetId },
         },
         { repository }
       );

--- a/typescript/common-resolvers/src/import/format-coco/index.ts
+++ b/typescript/common-resolvers/src/import/format-coco/index.ts
@@ -1,0 +1,37 @@
+import JSZip from "jszip";
+import { v4 as uuidv4 } from "uuid";
+
+import type { UploadTargetHttp } from "@labelflow/graphql-types";
+
+import { ImportFunction } from "../types";
+
+export const importCoco: ImportFunction = async (zipBlob, { repository }) => {
+  const zip = await JSZip.loadAsync(zipBlob);
+  const annotationsFilePath = "";
+  zip.forEach(async (relativePath, file) => {
+    const fileBlob = await file.async("blob", () => {});
+    if (relativePath.split("/").includes("images")) {
+      const uploadTarget = await repository.upload.getUploadTarget(uuidv4());
+      if (!(uploadTarget as UploadTargetHttp)?.downloadUrl) {
+        throw new Error("Can't direct upload this image.");
+      }
+      repository.upload.put(
+        (uploadTarget as UploadTargetHttp)?.downloadUrl,
+        fileBlob
+      );
+      console.log("uploaded image ", relativePath);
+    } else {
+      const pathSplitExtension = relativePath.split(".");
+      if (!(pathSplitExtension[pathSplitExtension.length - 1] === "json")) {
+        throw new Error(`Received an unknown file: ${relativePath}`);
+      }
+      if (annotationsFilePath) {
+        throw new Error(
+          `Already received an annotation file ${annotationsFilePath} and found another json file named ${relativePath}`
+        );
+      }
+      // Supposed to implement the import of that file now
+    }
+  });
+  // Do sthg
+};

--- a/typescript/common-resolvers/src/import/index.ts
+++ b/typescript/common-resolvers/src/import/index.ts
@@ -11,7 +11,10 @@ const makeImport = async (
   args: MutationImportDatasetArgs,
   { repository }: Context
 ): Promise<void> => {
-  const zipBlob: Blob = new Blob([await repository.upload.get(args.data.url)]);
+  const datasetBlob: Blob = new Blob([
+    await repository.upload.get(args.data.url),
+  ]);
+  await repository.upload.delete(args.data.url); // Remove blob from cache immediately
   // TODO: handle when args.where.slugs is used over args.where.id
   if (!args.where.id) {
     throw new Error(
@@ -24,7 +27,7 @@ const makeImport = async (
     }
     case ExportFormat.Coco: {
       return importCoco(
-        zipBlob,
+        datasetBlob,
         args.where?.id,
         {
           repository,

--- a/typescript/common-resolvers/src/import/index.ts
+++ b/typescript/common-resolvers/src/import/index.ts
@@ -10,14 +10,15 @@ import { Context } from "../types";
 const makeImport = async (
   args: MutationImportDatasetArgs,
   { repository }: Context
-): Promise<Blob> => {
-  const zipBlob: Blob = new Blob([await repository.upload.get(args.url)]);
-  switch (args.format) {
+): Promise<void> => {
+  const zipBlob: Blob = new Blob([await repository.upload.get(args.data.url)]);
+  // TODO: handle when args.where.slugs is used over args.where.id
+  switch (args.data.format) {
     case ExportFormat.Yolo: {
       throw new Error("YOLO format not supported, but will be soon!");
     }
     case ExportFormat.Coco: {
-      return importCoco(zipBlob, {
+      return importCoco(zipBlob, args.where.id, {
         repository,
       });
     }

--- a/typescript/common-resolvers/src/import/index.ts
+++ b/typescript/common-resolvers/src/import/index.ts
@@ -1,0 +1,49 @@
+import {
+  MutationImportDatasetArgs,
+  ExportFormat,
+  ImportStatus,
+} from "@labelflow/graphql-types";
+
+import { importCoco } from "./format-coco";
+import { Context } from "../types";
+
+const makeImport = async (
+  args: MutationImportDatasetArgs,
+  { repository }: Context
+): Promise<Blob> => {
+  const zipBlob: Blob = new Blob([await repository.upload.get(args.url)]);
+  switch (args.format) {
+    case ExportFormat.Yolo: {
+      throw new Error("YOLO format not supported, but will be soon!");
+    }
+    case ExportFormat.Coco: {
+      return importCoco(zipBlob, {
+        repository,
+      });
+    }
+    default: {
+      throw new Error("Unsupported format");
+    }
+  }
+};
+
+const importDataset = async (
+  _: any,
+  args: MutationImportDatasetArgs,
+  { repository }: Context
+): Promise<ImportStatus> => {
+  try {
+    await makeImport(args, { repository });
+    return {};
+  } catch (e) {
+    return {
+      error: e.message,
+    };
+  }
+};
+
+export default {
+  Mutation: {
+    importDataset,
+  },
+};

--- a/typescript/common-resolvers/src/import/index.ts
+++ b/typescript/common-resolvers/src/import/index.ts
@@ -18,7 +18,7 @@ const makeImport = async (
       throw new Error("YOLO format not supported, but will be soon!");
     }
     case ExportFormat.Coco: {
-      return importCoco(zipBlob, args.where.id, {
+      return importCoco(zipBlob, args.where.id, args.data?.options?.coco, {
         repository,
       });
     }
@@ -38,7 +38,7 @@ const importDataset = async (
     return {};
   } catch (e) {
     return {
-      error: e.message,
+      error: `${e.message}\n${e.stack}`,
     };
   }
 };

--- a/typescript/common-resolvers/src/import/index.ts
+++ b/typescript/common-resolvers/src/import/index.ts
@@ -13,14 +13,24 @@ const makeImport = async (
 ): Promise<void> => {
   const zipBlob: Blob = new Blob([await repository.upload.get(args.data.url)]);
   // TODO: handle when args.where.slugs is used over args.where.id
+  if (!args.where.id) {
+    throw new Error(
+      "Expecting args.where.id to be defined. Can't import from dataset slug."
+    );
+  }
   switch (args.data.format) {
     case ExportFormat.Yolo: {
       throw new Error("YOLO format not supported, but will be soon!");
     }
     case ExportFormat.Coco: {
-      return importCoco(zipBlob, args.where.id, args.data?.options?.coco, {
-        repository,
-      });
+      return importCoco(
+        zipBlob,
+        args.where?.id,
+        {
+          repository,
+        },
+        args.data?.options?.coco ?? undefined
+      );
     }
     default: {
       throw new Error("Unsupported format");

--- a/typescript/common-resolvers/src/import/types.ts
+++ b/typescript/common-resolvers/src/import/types.ts
@@ -4,6 +4,6 @@ import { Context } from "../types";
 export type ImportFunction = (
   zipBlob: Blob,
   datasetId: string,
-  options: ImportOptionsCoco,
-  context: Context
+  context: Context,
+  options?: ImportOptionsCoco
 ) => void;

--- a/typescript/common-resolvers/src/import/types.ts
+++ b/typescript/common-resolvers/src/import/types.ts
@@ -1,3 +1,7 @@
 import { Context } from "../types";
 
-export type ImportFunction = (zipBlob: Blob, context: Context) => void;
+export type ImportFunction = (
+  zipBlob: Blob,
+  datasetId: string,
+  context: Context
+) => void;

--- a/typescript/common-resolvers/src/import/types.ts
+++ b/typescript/common-resolvers/src/import/types.ts
@@ -1,7 +1,9 @@
+import { ImportOptionsCoco } from "@labelflow/graphql-types";
 import { Context } from "../types";
 
 export type ImportFunction = (
   zipBlob: Blob,
   datasetId: string,
+  options: ImportOptionsCoco,
   context: Context
 ) => void;

--- a/typescript/common-resolvers/src/import/types.ts
+++ b/typescript/common-resolvers/src/import/types.ts
@@ -1,0 +1,3 @@
+import { Context } from "../types";
+
+export type ImportFunction = (zipBlob: Blob, context: Context) => void;

--- a/typescript/common-resolvers/src/index.ts
+++ b/typescript/common-resolvers/src/index.ts
@@ -1,5 +1,6 @@
 import { mergeResolvers } from "@graphql-tools/merge";
 import exportResolvers from "./export";
+import importResolvers from "./import";
 import imageResolvers from "./image";
 import labelResolvers from "./label";
 import labelClassResolvers from "./label-class";
@@ -9,6 +10,7 @@ import uploadResolvers from "./upload";
 
 export const commonResolvers = mergeResolvers([
   exportResolvers,
+  importResolvers,
   imageResolvers,
   labelResolvers,
   labelClassResolvers,

--- a/typescript/common-resolvers/src/label-class.ts
+++ b/typescript/common-resolvers/src/label-class.ts
@@ -11,6 +11,7 @@ import type {
 
 import { Context, DbLabelClass } from "./types";
 import { throwIfResolvesToNil } from "./utils/throw-if-resolves-to-nil";
+import { hexColorSequence } from "./utils/class-color-generator";
 
 // Queries
 const labels = async (
@@ -68,7 +69,8 @@ const createLabelClass = async (
     createdAt: now.toISOString(),
     updatedAt: now.toISOString(),
     name,
-    color,
+    color:
+      color ?? hexColorSequence[numberLabelClasses % hexColorSequence.length],
     datasetId,
   };
   await repository.labelClass.add(newLabelClassEntity);

--- a/typescript/common-resolvers/src/types.ts
+++ b/typescript/common-resolvers/src/types.ts
@@ -36,9 +36,11 @@ export type DbLabelCreateInput = WithCreatedAtAndUpdatedAt<DbLabel>;
 export type DbLabelClass = Omit<GeneratedLabelClass, "labels" | "dataset"> & {
   datasetId: string;
 };
-export type DbLabelClassCreateInput = Required<NoUndefinedField<WithCreatedAtAndUpdatedAt<
-  LabelClassCreateInput & { index: number }
->>>;
+export type DbLabelClassCreateInput = Required<
+  NoUndefinedField<
+    WithCreatedAtAndUpdatedAt<LabelClassCreateInput & { index: number }>
+  >
+>;
 
 export type DbExample = GeneratedExample;
 

--- a/typescript/common-resolvers/src/types.ts
+++ b/typescript/common-resolvers/src/types.ts
@@ -36,9 +36,9 @@ export type DbLabelCreateInput = WithCreatedAtAndUpdatedAt<DbLabel>;
 export type DbLabelClass = Omit<GeneratedLabelClass, "labels" | "dataset"> & {
   datasetId: string;
 };
-export type DbLabelClassCreateInput = WithCreatedAtAndUpdatedAt<
+export type DbLabelClassCreateInput = Required<NoUndefinedField<WithCreatedAtAndUpdatedAt<
   LabelClassCreateInput & { index: number }
->;
+>>>;
 
 export type DbExample = GeneratedExample;
 

--- a/typescript/common-resolvers/src/utils/class-color-generator.ts
+++ b/typescript/common-resolvers/src/utils/class-color-generator.ts
@@ -1,0 +1,119 @@
+// export const hexColorSequence = [
+//   "#ef4444",
+//   "#eab308",
+//   "#10b981",
+//   "#0ea5e9",
+//   "#8b5cf6",
+//   "#ec4899",
+//   "#f97316",
+//   "#84cc16",
+//   "#14b8a6",
+//   "#3b82f6",
+//   "#a855f7",
+//   "#f43f5e",
+//   "#f59e0b",
+//   "#22c55e",
+//   "#06b6d4",
+//   "#6366f1",
+//   "#d946ef",
+// ];
+
+// export const hexColorSequence400 = [
+//   "#F87171",
+//   "#FACC15",
+//   "#34D399",
+//   "#38BDF8",
+//   "#A78BFA",
+//   "#F472B6",
+//   "#FB923C",
+//   "#A3E635",
+//   "#2DD4BF",
+//   "#60A5FA",
+//   "#C084FC",
+//   "#FB7185",
+//   "#FBBF24",
+//   "#4ADE80",
+//   "#22D3EE",
+//   "#818CF8",
+//   "#E879F9",
+// ];
+
+// const hexColorSequence600 = [
+//   "#DC2626",
+//   "#CA8A04",
+//   "#059669",
+//   "#0284C7",
+//   "#7C3AED",
+//   "#DB2777",
+//   "#EA580C",
+//   "#65A30D",
+//   "#0D9488",
+//   "#2563EB",
+//   "#9333EA",
+//   "#E11D48",
+//   "#D97706",
+//   "#16A34A",
+//   "#0891B2",
+//   "#4F46E5",
+//   "#C026D3",
+// ];
+
+export const hexColorSequence = [
+  "#F87171",
+  "#FACC15",
+  "#34D399",
+  "#38BDF8",
+  "#A78BFA",
+  "#DB2777",
+  "#FB923C",
+  "#65A30D",
+  "#0D9488",
+  "#2563EB",
+  "#9333EA",
+  "#FB7185",
+  "#FBBF24",
+  "#4ADE80",
+  "#22D3EE",
+  "#818CF8",
+  "#E879F9",
+  "#DC2626",
+  "#CA8A04",
+  "#059669",
+  "#0284C7",
+  "#7C3AED",
+  "#F472B6",
+  "#EA580C",
+  "#A3E635",
+  "#2DD4BF",
+  "#60A5FA",
+  "#C084FC",
+  "#E11D48",
+  "#D97706",
+  "#16A34A",
+  "#0891B2",
+  "#4F46E5",
+  "#C026D3",
+];
+
+// It's charkra's gray.200
+export const noneClassColor = "#E2E8F0";
+
+export const previousHexToNextHexMap: { [key: string]: string } =
+  hexColorSequence.reduce((accumulator, colorHex, index) => {
+    const indexOfNextColor = (index + 1) % hexColorSequence.length; // The number that you are adding to index and the length of the array have to be prime numbers between each other
+    const nextColorHex = hexColorSequence[indexOfNextColor];
+    return {
+      ...accumulator,
+      [colorHex]: nextColorHex,
+    };
+  }, {});
+export const getNextClassColor = (lastHexClassColor: string): string => {
+  if (lastHexClassColor in previousHexToNextHexMap) {
+    return previousHexToNextHexMap?.[lastHexClassColor];
+  }
+  throw new Error(
+    `Unrecognized color ${lastHexClassColor} passed to getNextClassColor, it should be one among:\n\t- ${Object.keys(
+      previousHexToNextHexMap
+    ).join("\n\t- ")}`
+  );
+};

--- a/typescript/graphql-types/src/graphql-types.generated.ts
+++ b/typescript/graphql-types/src/graphql-types.generated.ts
@@ -167,6 +167,11 @@ export type ImagesAggregates = {
   totalCount: Scalars['Int'];
 };
 
+export type ImportStatus = {
+  __typename?: 'ImportStatus';
+  error?: Maybe<Scalars['String']>;
+};
+
 
 export type Label = {
   __typename?: 'Label';
@@ -303,6 +308,7 @@ export type Mutation = {
   createDemoDataset?: Maybe<Dataset>;
   updateDataset?: Maybe<Dataset>;
   deleteDataset?: Maybe<Dataset>;
+  importDataset?: Maybe<ImportStatus>;
   createWorkspace?: Maybe<Workspace>;
   updateWorkspace?: Maybe<Workspace>;
   createMembership?: Maybe<Membership>;
@@ -378,6 +384,12 @@ export type MutationUpdateDatasetArgs = {
 
 export type MutationDeleteDatasetArgs = {
   where: DatasetWhereUniqueInput;
+};
+
+
+export type MutationImportDatasetArgs = {
+  url: Scalars['String'];
+  format: ExportFormat;
 };
 
 
@@ -734,6 +746,7 @@ export type ResolversTypes = {
   ImageWhereInput: ImageWhereInput;
   ImageWhereUniqueInput: ImageWhereUniqueInput;
   ImagesAggregates: ResolverTypeWrapper<ImagesAggregates>;
+  ImportStatus: ResolverTypeWrapper<ImportStatus>;
   JSON: ResolverTypeWrapper<Scalars['JSON']>;
   Label: ResolverTypeWrapper<Label>;
   Float: ResolverTypeWrapper<Scalars['Float']>;
@@ -802,6 +815,7 @@ export type ResolversParentTypes = {
   ImageWhereInput: ImageWhereInput;
   ImageWhereUniqueInput: ImageWhereUniqueInput;
   ImagesAggregates: ImagesAggregates;
+  ImportStatus: ImportStatus;
   JSON: Scalars['JSON'];
   Label: Label;
   Float: Scalars['Float'];
@@ -897,6 +911,11 @@ export type ImagesAggregatesResolvers<ContextType = any, ParentType extends Reso
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type ImportStatusResolvers<ContextType = any, ParentType extends ResolversParentTypes['ImportStatus'] = ResolversParentTypes['ImportStatus']> = {
+  error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export interface JsonScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['JSON'], any> {
   name: 'JSON';
 }
@@ -963,6 +982,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   createDemoDataset?: Resolver<Maybe<ResolversTypes['Dataset']>, ParentType, ContextType>;
   updateDataset?: Resolver<Maybe<ResolversTypes['Dataset']>, ParentType, ContextType, RequireFields<MutationUpdateDatasetArgs, 'where' | 'data'>>;
   deleteDataset?: Resolver<Maybe<ResolversTypes['Dataset']>, ParentType, ContextType, RequireFields<MutationDeleteDatasetArgs, 'where'>>;
+  importDataset?: Resolver<Maybe<ResolversTypes['ImportStatus']>, ParentType, ContextType, RequireFields<MutationImportDatasetArgs, 'url' | 'format'>>;
   createWorkspace?: Resolver<Maybe<ResolversTypes['Workspace']>, ParentType, ContextType, RequireFields<MutationCreateWorkspaceArgs, 'data'>>;
   updateWorkspace?: Resolver<Maybe<ResolversTypes['Workspace']>, ParentType, ContextType, RequireFields<MutationUpdateWorkspaceArgs, 'where' | 'data'>>;
   createMembership?: Resolver<Maybe<ResolversTypes['Membership']>, ParentType, ContextType, RequireFields<MutationCreateMembershipArgs, 'data'>>;
@@ -1048,6 +1068,7 @@ export type Resolvers<ContextType = any> = {
   Geometry?: GeometryResolvers<ContextType>;
   Image?: ImageResolvers<ContextType>;
   ImagesAggregates?: ImagesAggregatesResolvers<ContextType>;
+  ImportStatus?: ImportStatusResolvers<ContextType>;
   JSON?: GraphQLScalarType;
   Label?: LabelResolvers<ContextType>;
   LabelClass?: LabelClassResolvers<ContextType>;

--- a/typescript/graphql-types/src/graphql-types.generated.ts
+++ b/typescript/graphql-types/src/graphql-types.generated.ts
@@ -208,7 +208,7 @@ export type LabelClass = {
 export type LabelClassCreateInput = {
   id?: Maybe<Scalars['ID']>;
   name: Scalars['String'];
-  color: Scalars['ColorHex'];
+  color?: Maybe<Scalars['ColorHex']>;
   datasetId: Scalars['ID'];
 };
 

--- a/typescript/graphql-types/src/graphql-types.generated.ts
+++ b/typescript/graphql-types/src/graphql-types.generated.ts
@@ -49,6 +49,7 @@ export type DatasetCreateInput = {
 export type DatasetImportInput = {
   url: Scalars['String'];
   format: ExportFormat;
+  options?: Maybe<ImportOptions>;
 };
 
 export type DatasetUpdateInput = {
@@ -170,6 +171,14 @@ export type ImageWhereUniqueInput = {
 export type ImagesAggregates = {
   __typename?: 'ImagesAggregates';
   totalCount: Scalars['Int'];
+};
+
+export type ImportOptions = {
+  coco?: Maybe<ImportOptionsCoco>;
+};
+
+export type ImportOptionsCoco = {
+  annotationsOnly?: Maybe<Scalars['Boolean']>;
 };
 
 export type ImportStatus = {
@@ -752,6 +761,8 @@ export type ResolversTypes = {
   ImageWhereInput: ImageWhereInput;
   ImageWhereUniqueInput: ImageWhereUniqueInput;
   ImagesAggregates: ResolverTypeWrapper<ImagesAggregates>;
+  ImportOptions: ImportOptions;
+  ImportOptionsCoco: ImportOptionsCoco;
   ImportStatus: ResolverTypeWrapper<ImportStatus>;
   JSON: ResolverTypeWrapper<Scalars['JSON']>;
   Label: ResolverTypeWrapper<Label>;
@@ -822,6 +833,8 @@ export type ResolversParentTypes = {
   ImageWhereInput: ImageWhereInput;
   ImageWhereUniqueInput: ImageWhereUniqueInput;
   ImagesAggregates: ImagesAggregates;
+  ImportOptions: ImportOptions;
+  ImportOptionsCoco: ImportOptionsCoco;
   ImportStatus: ImportStatus;
   JSON: Scalars['JSON'];
   Label: Label;

--- a/typescript/graphql-types/src/graphql-types.generated.ts
+++ b/typescript/graphql-types/src/graphql-types.generated.ts
@@ -46,6 +46,11 @@ export type DatasetCreateInput = {
   workspaceSlug: Scalars['String'];
 };
 
+export type DatasetImportInput = {
+  url: Scalars['String'];
+  format: ExportFormat;
+};
+
 export type DatasetUpdateInput = {
   name: Scalars['String'];
 };
@@ -388,8 +393,8 @@ export type MutationDeleteDatasetArgs = {
 
 
 export type MutationImportDatasetArgs = {
-  url: Scalars['String'];
-  format: ExportFormat;
+  where: DatasetWhereUniqueInput;
+  data: DatasetImportInput;
 };
 
 
@@ -723,6 +728,7 @@ export type ResolversTypes = {
   String: ResolverTypeWrapper<Scalars['String']>;
   Int: ResolverTypeWrapper<Scalars['Int']>;
   DatasetCreateInput: DatasetCreateInput;
+  DatasetImportInput: DatasetImportInput;
   DatasetUpdateInput: DatasetUpdateInput;
   DatasetWhereInput: DatasetWhereInput;
   DatasetWhereUniqueInput: DatasetWhereUniqueInput;
@@ -794,6 +800,7 @@ export type ResolversParentTypes = {
   String: Scalars['String'];
   Int: Scalars['Int'];
   DatasetCreateInput: DatasetCreateInput;
+  DatasetImportInput: DatasetImportInput;
   DatasetUpdateInput: DatasetUpdateInput;
   DatasetWhereInput: DatasetWhereInput;
   DatasetWhereUniqueInput: DatasetWhereUniqueInput;
@@ -982,7 +989,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   createDemoDataset?: Resolver<Maybe<ResolversTypes['Dataset']>, ParentType, ContextType>;
   updateDataset?: Resolver<Maybe<ResolversTypes['Dataset']>, ParentType, ContextType, RequireFields<MutationUpdateDatasetArgs, 'where' | 'data'>>;
   deleteDataset?: Resolver<Maybe<ResolversTypes['Dataset']>, ParentType, ContextType, RequireFields<MutationDeleteDatasetArgs, 'where'>>;
-  importDataset?: Resolver<Maybe<ResolversTypes['ImportStatus']>, ParentType, ContextType, RequireFields<MutationImportDatasetArgs, 'url' | 'format'>>;
+  importDataset?: Resolver<Maybe<ResolversTypes['ImportStatus']>, ParentType, ContextType, RequireFields<MutationImportDatasetArgs, 'where' | 'data'>>;
   createWorkspace?: Resolver<Maybe<ResolversTypes['Workspace']>, ParentType, ContextType, RequireFields<MutationCreateWorkspaceArgs, 'data'>>;
   updateWorkspace?: Resolver<Maybe<ResolversTypes['Workspace']>, ParentType, ContextType, RequireFields<MutationUpdateWorkspaceArgs, 'where' | 'data'>>;
   createMembership?: Resolver<Maybe<ResolversTypes['Membership']>, ParentType, ContextType, RequireFields<MutationCreateMembershipArgs, 'data'>>;

--- a/typescript/web/package.json
+++ b/typescript/web/package.json
@@ -65,6 +65,7 @@
     "node-polyfill-webpack-plugin": "^1.1.2",
     "nodemailer": "^6.6.3",
     "ol": "6.6.1",
+    "path-browserify": "1.0.1",
     "postcss": "^8.3.5",
     "query-string": "^7.0.0",
     "react": "17.x",

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/dropzone.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/dropzone.tsx
@@ -23,7 +23,7 @@ export const Dropzone = ({
     getRootProps: () => object;
     getInputProps: () => object;
   } = useDropzone({
-    accept: "image/jpeg, image/png, image/bmp, application/zip",
+    accept: "image/jpeg, image/png, image/bmp, application/zip, application/json",
   });
 
   useEffect(() => {

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/dropzone.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/dropzone.tsx
@@ -23,7 +23,7 @@ export const Dropzone = ({
     getRootProps: () => object;
     getInputProps: () => object;
   } = useDropzone({
-    accept: "image/jpeg, image/png, image/bmp",
+    accept: "image/jpeg, image/png, image/bmp, application/zip",
   });
 
   useEffect(() => {

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/dropzone.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/dropzone.tsx
@@ -23,7 +23,8 @@ export const Dropzone = ({
     getRootProps: () => object;
     getInputProps: () => object;
   } = useDropzone({
-    accept: "image/jpeg, image/png, image/bmp, application/zip, application/json",
+    accept:
+      "image/jpeg, image/png, image/bmp, application/zip, application/json",
   });
 
   useEffect(() => {

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/modal-dropzone.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/modal-dropzone.tsx
@@ -242,15 +242,18 @@ export const ImportImagesModalDropzone = ({
                         format: ExportFormat.Coco,
                       },
                     },
-                    refetchQueries: ["getDatasetData"],
+                    refetchQueries: [
+                      "getDatasetData",
+                      "getImageLabels",
+                      "getLabel",
+                      "countLabelsOfDataset",
+                    ],
                   });
-                  console.log(
-                    `dataImportDataset = ${JSON.stringify(
-                      dataImportDataset,
-                      null,
-                      2
-                    )}`
-                  );
+                  if (dataImportDataset?.data?.importDataset?.error) {
+                    throw new Error(
+                      dataImportDataset?.data?.importDataset?.error
+                    );
+                  }
                 }
 
                 return setFileUploadStatuses((previousFileUploadStatuses) => {

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/modal-dropzone.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/modal-dropzone.tsx
@@ -232,7 +232,7 @@ export const ImportImagesModalDropzone = ({
                     },
                   });
                 } else {
-                  // It's a zip archive
+                  // It's a dataset / annotations that we want to import
                   const dataImportDataset = await apolloClient.mutate({
                     mutation: importDataset,
                     variables: {
@@ -240,6 +240,12 @@ export const ImportImagesModalDropzone = ({
                       data: {
                         url: target.downloadUrl,
                         format: ExportFormat.Coco,
+                        options: {
+                          coco: {
+                            annotationsOnly:
+                              acceptedFile.file.type === "application/json",
+                          },
+                        },
                       },
                     },
                     refetchQueries: [

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/modal-dropzone.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/modal-dropzone.tsx
@@ -80,8 +80,11 @@ const getDataset = gql`
 `;
 
 const importDataset = gql`
-  mutation importDataset($url: String!, $format: ExportFormat!) {
-    importDataset(url: $url, format: $format) {
+  mutation importDataset(
+    $where: DatasetWhereUniqueInput!
+    $data: DatasetImportInput!
+  ) {
+    importDataset(where: $where, data: $data) {
       error
     }
   }
@@ -233,9 +236,13 @@ export const ImportImagesModalDropzone = ({
                   const dataImportDataset = await apolloClient.mutate({
                     mutation: importDataset,
                     variables: {
-                      url: target.downloadUrl,
-                      format: ExportFormat.Coco,
+                      where: { id: datasetId },
+                      data: {
+                        url: target.downloadUrl,
+                        format: ExportFormat.Coco,
+                      },
                     },
+                    refetchQueries: ["getDatasetData"],
                   });
                   console.log(
                     `dataImportDataset = ${JSON.stringify(

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/modal-dropzone.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/modal-dropzone.tsx
@@ -247,6 +247,7 @@ export const ImportImagesModalDropzone = ({
                       "getImageLabels",
                       "getLabel",
                       "countLabelsOfDataset",
+                      "getDatasetLabelClasses",
                     ],
                   });
                   if (dataImportDataset?.data?.importDataset?.error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6379,6 +6379,7 @@ __metadata:
     node-polyfill-webpack-plugin: ^1.1.2
     nodemailer: ^6.6.3
     ol: 6.6.1
+    path-browserify: 1.0.1
     postcss: ^8.3.5
     query-string: ^7.0.0
     react: 17.x


### PR DESCRIPTION
# Feature

## Work performed

- Created a new resolver named `importDataset` (counterpart of `exportDataset`)
- Enabled zip and json files in the dropzone of the "import images" modal
- Whether you uploaded a json or a zip file is an option the client give to the resolver
- The resolver skips images and labelclasses that are already in the dataset, check is made on file name
- The resolver infers whether the annotations are boxes or polygons (no other way since coco doesn't provide type information)

## Results

<!--- Does this MR fully implement the new feature? If not why? Create and link new issues. -->

## Problems encountered

<!--- Explain problems that were encountered when implementing this MR -->

## Caveats

- I had to copy `typescript/web/src/utils/class-color-generator.ts` to the `common-resolvers` utilities to enable proper colouring of the classes in the resolver
- No granular tracking of the status of the import, it's binary for the whole import

## Resolved issues

Closes #227

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
