### PR TITLE
Disambiguate dataset name at export

### DIFF
--- a/typescript/web/src/components/export-button/export-modal/index.tsx
+++ b/typescript/web/src/components/export-button/export-modal/index.tsx
@@ -64,12 +64,14 @@ export const countLabelsOfDatasetQuery = gql`
 
 const exportDataset = async ({
   datasetId,
+  datasetSlug,
   setIsExportRunning,
   client,
   format,
   options,
 }: {
   datasetId: string;
+  datasetSlug: string;
   setIsExportRunning: Dispatch<SetStateAction<boolean>>;
   client: ApolloClient<Object>;
   format: ExportFormat;
@@ -84,7 +86,7 @@ const exportDataset = async ({
     .join("-")}T${String(dateObject.getHours()).padStart(2, "0")}${String(
     dateObject.getMinutes()
   ).padStart(2, "0")}${String(dateObject.getSeconds()).padStart(2, "0")}`;
-  const datasetName = `dataset-${date}-${format.toLowerCase()}`;
+  const datasetName = `${datasetSlug}-${format.toLowerCase()}-${date}`;
   const {
     data: { exportDataset: exportDatasetUrl },
   } = await client.query({
@@ -143,6 +145,7 @@ export const ExportModal = ({
     async (options: ExportOptions) =>
       await exportDataset({
         datasetId,
+        datasetSlug,
         setIsExportRunning,
         client,
         format: exportFormat,


### PR DESCRIPTION
# Feature

## Work performed

I moved the export template of the dataset from `dataset-${date}-${format}` to `${datasetSlug}-${format}-${date}`
This originated from the work on the webinar where I had to export different datasets and got lost between ambiguous names

For instance, I got: "dataset-2021-09-23T173448-coco" vs "dataset-2021-09-23T173832-coco"
With that change they become: "training-powerlines-coco-2021-09-23T173448" vs "test-powerlines-coco-2021-09-23T173832" which is much more readable

## Results

<!--- Does this MR fully implement the new feature? If not why? Create and link new issues. -->

## Problems encountered

<!--- Explain problems that were encountered when implementing this MR -->

## Caveats

<!--- Any particular attention point with what you did? -->

## Resolved issues

<!--- List references to issues that this PR resolves -->

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
