### PR TITLE
Fix bug at build time when user does not have a Sentry token

### DIFF
--- a/typescript/web/next.config.js
+++ b/typescript/web/next.config.js
@@ -23,6 +23,12 @@ const SentryWebpackPluginOptions = {
 
 module.exports = withSentryConfig(
   withPWA({
+    sentry: {
+      disableServerWebpackPlugin:
+        process.env.SENTRY_AUTH_TOKEN != null ? false : true,
+      disableClientWebpackPlugin:
+        process.env.SENTRY_AUTH_TOKEN != null ? false : true,
+    },
     images: {
       deviceSizes: [
         320, 480, 640, 750, 828, 960, 1080, 1200, 1440, 1920, 2048, 2560, 3840,


### PR DESCRIPTION
# Feature

## Work performed

- Fix bug at build time when user does not have a Sentry token

## Results

In #460 the build of the web-app failed due to the Sentry token missing in the environment variables. This is needed for the Sentry CLI to upload the source maps to the relevant Sentry project, and it crashes if Sentry does not find the token to be able to connect to the relevant project.

Here we disable the source maps uploads if we can't find the Sentry token in the environment variables, enabling thus to compile the app. I tested to build the app removing the Sentry token env var and it worked, so this should fix #460.

## Resolved issues

Closes #460 