### PR TITLE
Display blog post details in social media previews

### DIFF
--- a/typescript/web/src/components/meta.tsx
+++ b/typescript/web/src/components/meta.tsx
@@ -8,6 +8,7 @@ type Props = {
   desc?: string;
   canonical?: string;
   images?: OpenGraphImages[];
+  noImage?: boolean;
 };
 
 const defaultImages = [
@@ -30,6 +31,7 @@ export const Meta = ({
   desc = "The fastest and simplest image labelling tool on the Internet!",
   canonical = "https://labelflow.ai/",
   images = defaultImages,
+  noImage = false,
 }: Props) => (
   <>
     <NextSeo
@@ -42,7 +44,7 @@ export const Meta = ({
         title,
         description: desc,
         locale: "en_US",
-        images,
+        images: noImage ? undefined : images,
       }}
       twitter={{
         handle: "@VLecrubier",

--- a/typescript/web/src/components/meta.tsx
+++ b/typescript/web/src/components/meta.tsx
@@ -8,7 +8,6 @@ type Props = {
   desc?: string;
   canonical?: string;
   images?: OpenGraphImages[];
-  noImage?: boolean;
 };
 
 const defaultImages = [
@@ -31,7 +30,6 @@ export const Meta = ({
   desc = "The fastest and simplest image labelling tool on the Internet!",
   canonical = "https://labelflow.ai/",
   images = defaultImages,
-  noImage = false,
 }: Props) => (
   <>
     <NextSeo
@@ -44,7 +42,7 @@ export const Meta = ({
         title,
         description: desc,
         locale: "en_US",
-        images: noImage ? undefined : images,
+        images,
       }}
       twitter={{
         handle: "@VLecrubier",

--- a/typescript/web/src/components/meta.tsx
+++ b/typescript/web/src/components/meta.tsx
@@ -1,17 +1,35 @@
 import * as React from "react";
 import { NextSeo } from "next-seo";
 import Head from "next/head";
+import { OpenGraphImages } from "next-seo/lib/types";
 
 type Props = {
   title?: string;
   desc?: string;
   canonical?: string;
+  images?: OpenGraphImages[];
 };
+
+const defaultImages = [
+  {
+    url: "https://labelflow.ai/static/img/seo-img.png",
+    width: 1200,
+    height: 630,
+    alt: "LabelFlow",
+  },
+  {
+    url: "https://labelflow.ai/static/img/seo-img@5.png",
+    width: 600,
+    height: 315,
+    alt: "LabelFlow",
+  },
+];
 
 export const Meta = ({
   title = "LabelFlow: The open standard platform for image labelling.",
   desc = "The fastest and simplest image labelling tool on the Internet!",
   canonical = "https://labelflow.ai/",
+  images = defaultImages,
 }: Props) => (
   <>
     <NextSeo
@@ -24,20 +42,7 @@ export const Meta = ({
         title,
         description: desc,
         locale: "en_US",
-        images: [
-          {
-            url: "https://labelflow.ai/static/img/seo-img.png",
-            width: 1200,
-            height: 630,
-            alt: "LabelFlow",
-          },
-          {
-            url: "https://labelflow.ai/static/img/seo-img@5.png",
-            width: 600,
-            height: 315,
-            alt: "LabelFlow",
-          },
-        ],
+        images,
       }}
       twitter={{
         handle: "@VLecrubier",

--- a/typescript/web/src/pages/_app.tsx
+++ b/typescript/web/src/pages/_app.tsx
@@ -15,8 +15,6 @@ import { pageView } from "../utils/google-analytics";
 import { theme } from "../theme";
 import { client } from "../connectors/apollo-client/client";
 import { QueryParamProvider } from "../utils/query-params-provider";
-
-import { Meta } from "../components/meta";
 import ErrorPage from "./_error";
 
 interface InitialProps {
@@ -68,7 +66,6 @@ const App = (props: AppProps & InitialProps) => {
           <ApolloProvider client={client}>
             <QueryParamProvider>
               <ChakraProvider theme={theme} resetCSS>
-                <Meta noImage />
                 <Head>
                   {/* Set proper initial appearance of content for mobile */}
                   <meta

--- a/typescript/web/src/pages/_app.tsx
+++ b/typescript/web/src/pages/_app.tsx
@@ -68,7 +68,7 @@ const App = (props: AppProps & InitialProps) => {
           <ApolloProvider client={client}>
             <QueryParamProvider>
               <ChakraProvider theme={theme} resetCSS>
-                <Meta />
+                <Meta noImage />
                 <Head>
                   {/* Set proper initial appearance of content for mobile */}
                   <meta

--- a/typescript/web/src/pages/posts/[slug].tsx
+++ b/typescript/web/src/pages/posts/[slug].tsx
@@ -29,7 +29,20 @@ export default function Posts({
   return (
     <>
       <ServiceWorkerManagerBackground />
-      <Meta title={`LabelFlow | ${article?.title}`} />
+      <Meta
+        title={`LabelFlow | ${article?.title}`}
+        desc={article?.description}
+        images={
+          article?.image?.url !== null
+            ? [
+                {
+                  url: article.image.url,
+                  alt: "LabelFlow",
+                },
+              ]
+            : undefined
+        }
+      />
       <CookieBanner />
       <Box minH="640px">
         <NavBar />


### PR DESCRIPTION
# Feature

## Work performed

- Change metadata fields in the blog post page in order to display the post image and description in social media previews

## Results

<img width="538" alt="Screenshot 2021-09-30 at 17 15 41" src="https://user-images.githubusercontent.com/17384901/135486958-9a45fe75-1fb6-4c25-99c8-bdce64ca4043.png">


## Problems encountered

The `<Meta />` tag that was placed in `_app.tsx` was overwriting the preview image set by the blog post page, so I added a `noImage` prop so that it does not get ovwerwritten.

## Resolved issues

Closes #470 