### PR TITLE
Enable to set classification class from shortcut

### DIFF
--- a/cypress/integration/class-selection-popover.ts
+++ b/cypress/integration/class-selection-popover.ts
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client";
 
-import { LabelCreateInput } from "../../typescript/graphql-types";
+import { LabelCreateInput, LabelType } from "../../typescript/graphql-types";
 import { client } from "../../typescript/web/src/connectors/apollo-client/schema-client";
 
 const createDataset = async (name: string) => {
@@ -128,8 +128,9 @@ describe("Class selection popover", () => {
       await createLabel({
         imageId,
         labelClassId,
+        type: LabelType.Box,
         geometry: {
-          type: "Polygon",
+          type: LabelType.Box,
           coordinates: [
             [
               [0, 900],

--- a/cypress/integration/class-selection-popover.ts
+++ b/cypress/integration/class-selection-popover.ts
@@ -237,6 +237,7 @@ describe("Class selection popover", () => {
 
     cy.wait(420);
     cy.get('[aria-label="Selection tool"]').click();
+    cy.get("main").click(500, 150);
     cy.get('[aria-label="Open class selection popover"]').click();
     cy.get('[aria-label="Class selection menu popover"]')
       .contains("None")

--- a/cypress/integration/classification.ts
+++ b/cypress/integration/classification.ts
@@ -266,5 +266,19 @@ describe("Classification", () => {
     cy.get('[aria-label="Classification tag:  My new class"]').should(
       "not.exist"
     );
+
+    // Open the context menu with "C" and set a class by using shortcut
+    cy.wait(420);
+    cy.get('[aria-label="Classification tag: Rocket"]').should("not.exist");
+    cy.get("body").type("c");
+    cy.focused().type("1");
+    cy.get('[aria-label="Classification tag: Rocket"]').should("be.visible");
+
+    // Open the context menu with "C" and remove a class by using shortcut
+    cy.wait(420);
+    cy.get('[aria-label="Classification tag: Rocket"]').should("be.visible");
+    cy.get("body").type("c");
+    cy.focused().type("1");
+    cy.get('[aria-label="Classification tag: Rocket"]').should("not.exist");
   });
 });

--- a/cypress/integration/dataset-manipulation.ts
+++ b/cypress/integration/dataset-manipulation.ts
@@ -6,6 +6,7 @@ describe("Dataset creation, edition, deletion", () => {
     // cy.visit("/");
     // cy.contains("Try it now").click();
     cy.visit("http://localhost:3000/local/datasets");
+    cy.wait(420);
     cy.contains("Create new dataset...").click();
     cy.get("input").type("cypress dataset");
     cy.contains("Start Labeling").click();

--- a/cypress/integration/image-navigation.ts
+++ b/cypress/integration/image-navigation.ts
@@ -52,8 +52,7 @@ describe("Image Navigation", () => {
       delay: 0,
     });
     cy.contains("Start Import").click();
-    cy.wait(10);
-    cy.get(`[aria-label="Close"]`).click();
+    cy.contains("Start labeling").click();
     cy.get("main").contains("photo").click();
 
     // Check that we can reach the end of the list

--- a/cypress/integration/image-navigation.ts
+++ b/cypress/integration/image-navigation.ts
@@ -43,6 +43,7 @@ describe("Image Navigation", () => {
       `http://localhost:3000/local/datasets/${datasetSlug}/images?modal-welcome=closed&modal-update-service-worker=update`
     );
     cy.contains("You don't have any images.").should("be.visible");
+    cy.wait(420);
     cy.get("header").within(() => {
       cy.contains("Add images").click();
     });
@@ -51,6 +52,7 @@ describe("Image Navigation", () => {
       delay: 0,
     });
     cy.contains("Start Import").click();
+    cy.wait(10);
     cy.get(`[aria-label="Close"]`).click();
     cy.get("main").contains("photo").click();
 

--- a/typescript/web/src/components/labeling-tool/drawing-tool-bar/drawing-tool.tsx
+++ b/typescript/web/src/components/labeling-tool/drawing-tool-bar/drawing-tool.tsx
@@ -6,6 +6,7 @@ import {
   Ref,
   MouseEventHandler,
 } from "react";
+import { gql, useQuery } from "@apollo/client";
 import {
   Tooltip,
   Popover,
@@ -87,6 +88,15 @@ export const ToolSelectionPopoverItem = (props: {
     </Box>
   );
 };
+
+const getLabelTypeQuery = gql`
+  query getLabelType($id: ID!) {
+    label(where: { id: $id }) {
+      id
+      type
+    }
+  }
+`;
 
 export const DrawingToolIcon = (props: {
   isDisabled: boolean;
@@ -210,6 +220,10 @@ export const DrawingTool = () => {
   const isImageLoading = useLabelingStore((state) => state.isImageLoading);
   const selectedTool = useLabelingStore((state) => state.selectedTool);
   const setSelectedTool = useLabelingStore((state) => state.setSelectedTool);
+  const selectedLabelId = useLabelingStore((state) => state.selectedLabelId);
+  const setSelectedLabelId = useLabelingStore(
+    (state) => state.setSelectedLabelId
+  );
   const [isPopoverOpened, doSetIsPopoverOpened] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const setIsPopoverOpened = useCallback((newState) => {
@@ -218,40 +232,57 @@ export const DrawingTool = () => {
       buttonRef.current.focus();
     }
   }, []);
+  const { data } = useQuery(getLabelTypeQuery, {
+    variables: { id: selectedLabelId },
+    skip: selectedLabelId == null,
+  });
+  const selectedLabelType = data?.label?.type ?? undefined;
+  const changeTool = useCallback(
+    (currentLabelType: Tools | undefined, toolType: Tools) => {
+      if (
+        currentLabelType != null &&
+        currentLabelType.toLowerCase() !== toolType.toLowerCase()
+      ) {
+        setSelectedLabelId(null);
+      }
+      setSelectedTool(toolType);
+    },
+    [setSelectedTool, setSelectedLabelId]
+  );
 
   useHotkeys(
     keymap.toolClassification.key,
     () => {
-      setSelectedTool(Tools.CLASSIFICATION);
+      changeTool(selectedLabelType, Tools.CLASSIFICATION);
     },
     {},
-    []
+    [changeTool, selectedLabelType]
   );
   useHotkeys(
     keymap.toolBoundingBox.key,
     () => {
-      setSelectedTool(Tools.BOX);
+      changeTool(selectedLabelType, Tools.BOX);
     },
     {},
-    []
+    [changeTool, selectedLabelType]
   );
   useHotkeys(
     keymap.toolPolygon.key,
     () => {
-      setSelectedTool(Tools.POLYGON);
+      changeTool(selectedLabelType, Tools.POLYGON);
     },
     {},
-    []
+    [changeTool, selectedLabelType]
   );
   useHotkeys(
     keymap.toolIog.key,
     () => {
       if (process.env.NEXT_PUBLIC_IOG_API_ENDPOINT) {
-        setSelectedTool(Tools.IOG);
+        changeTool(selectedLabelType, Tools.IOG);
       }
     },
     {},
-    []
+    [changeTool, selectedLabelType]
   );
   return (
     <Popover
@@ -270,7 +301,7 @@ export const DrawingTool = () => {
           e.stopPropagation();
         }}
         selectedTool={selectedTool}
-        setSelectedTool={setSelectedTool}
+        setSelectedTool={(tool: Tools) => changeTool(selectedLabelType, tool)}
       />
       <PopoverContent
         borderColor={mode("gray.200", "gray.600")}
@@ -286,7 +317,7 @@ export const DrawingTool = () => {
               shortcut={keymap.toolClassification.key}
               selected={selectedTool === Tools.CLASSIFICATION}
               onClick={() => {
-                setSelectedTool(Tools.CLASSIFICATION);
+                changeTool(selectedLabelType, Tools.CLASSIFICATION);
                 setIsPopoverOpened(false);
               }}
               ariaLabel="Classification tool"
@@ -300,7 +331,7 @@ export const DrawingTool = () => {
               shortcut={keymap.toolBoundingBox.key}
               selected={selectedTool === Tools.BOX}
               onClick={() => {
-                setSelectedTool(Tools.BOX);
+                changeTool(selectedLabelType, Tools.BOX);
                 setIsPopoverOpened(false);
               }}
               ariaLabel="Bounding box tool"
@@ -314,7 +345,7 @@ export const DrawingTool = () => {
               shortcut={keymap.toolPolygon.key}
               selected={selectedTool === Tools.POLYGON}
               onClick={() => {
-                setSelectedTool(Tools.POLYGON);
+                changeTool(selectedLabelType, Tools.POLYGON);
                 setIsPopoverOpened(false);
               }}
               ariaLabel="Polygon tool"
@@ -329,7 +360,7 @@ export const DrawingTool = () => {
                 shortcut={keymap.toolIog.key}
                 selected={selectedTool === Tools.IOG}
                 onClick={() => {
-                  setSelectedTool(Tools.IOG);
+                  changeTool(selectedLabelType, Tools.IOG);
                   setIsPopoverOpened(false);
                 }}
                 ariaLabel="Select iog tool"

--- a/typescript/web/src/components/labeling-tool/drawing-tool-bar/drawing-tool.tsx
+++ b/typescript/web/src/components/labeling-tool/drawing-tool-bar/drawing-tool.tsx
@@ -226,7 +226,7 @@ export const DrawingTool = () => {
     if (selectedTool !== Tools.SELECTION) {
       setSelectedLabelId(null);
     }
-  }, [selectedTool, setSelectedLabelId]);
+  }, [selectedTool]);
 
   useHotkeys(
     keymap.toolClassification.key,
@@ -234,7 +234,7 @@ export const DrawingTool = () => {
       setSelectedTool(Tools.CLASSIFICATION);
     },
     {},
-    [setSelectedTool, setSelectedLabelId]
+    [setSelectedTool]
   );
   useHotkeys(
     keymap.toolBoundingBox.key,
@@ -242,7 +242,7 @@ export const DrawingTool = () => {
       setSelectedTool(Tools.BOX);
     },
     {},
-    [setSelectedTool, setSelectedLabelId]
+    [setSelectedTool]
   );
   useHotkeys(
     keymap.toolPolygon.key,
@@ -250,7 +250,7 @@ export const DrawingTool = () => {
       setSelectedTool(Tools.POLYGON);
     },
     {},
-    [setSelectedTool, setSelectedLabelId]
+    [setSelectedTool]
   );
   useHotkeys(
     keymap.toolIog.key,
@@ -260,7 +260,7 @@ export const DrawingTool = () => {
       }
     },
     {},
-    [setSelectedTool, setSelectedLabelId]
+    [setSelectedTool]
   );
   return (
     <Popover
@@ -279,9 +279,7 @@ export const DrawingTool = () => {
           e.stopPropagation();
         }}
         selectedTool={selectedTool}
-        setSelectedTool={(tool: Tools) => {
-          setSelectedTool(tool);
-        }}
+        setSelectedTool={setSelectedTool}
       />
       <PopoverContent
         borderColor={mode("gray.200", "gray.600")}

--- a/typescript/web/src/components/labeling-tool/drawing-tool-bar/drawing-tool.tsx
+++ b/typescript/web/src/components/labeling-tool/drawing-tool-bar/drawing-tool.tsx
@@ -6,7 +6,6 @@ import {
   Ref,
   MouseEventHandler,
 } from "react";
-import { gql, useQuery } from "@apollo/client";
 import {
   Tooltip,
   Popover,
@@ -88,15 +87,6 @@ export const ToolSelectionPopoverItem = (props: {
     </Box>
   );
 };
-
-const getLabelTypeQuery = gql`
-  query getLabelType($id: ID!) {
-    label(where: { id: $id }) {
-      id
-      type
-    }
-  }
-`;
 
 export const DrawingToolIcon = (props: {
   isDisabled: boolean;
@@ -220,7 +210,6 @@ export const DrawingTool = () => {
   const isImageLoading = useLabelingStore((state) => state.isImageLoading);
   const selectedTool = useLabelingStore((state) => state.selectedTool);
   const setSelectedTool = useLabelingStore((state) => state.setSelectedTool);
-  const selectedLabelId = useLabelingStore((state) => state.selectedLabelId);
   const setSelectedLabelId = useLabelingStore(
     (state) => state.setSelectedLabelId
   );
@@ -232,57 +221,44 @@ export const DrawingTool = () => {
       buttonRef.current.focus();
     }
   }, []);
-  const { data } = useQuery(getLabelTypeQuery, {
-    variables: { id: selectedLabelId },
-    skip: selectedLabelId == null,
-  });
-  const selectedLabelType = data?.label?.type ?? undefined;
-  const changeTool = useCallback(
-    (currentLabelType: Tools | undefined, toolType: Tools) => {
-      if (
-        currentLabelType != null &&
-        currentLabelType.toLowerCase() !== toolType.toLowerCase()
-      ) {
-        setSelectedLabelId(null);
-      }
-      setSelectedTool(toolType);
-    },
-    [setSelectedTool, setSelectedLabelId]
-  );
 
   useHotkeys(
     keymap.toolClassification.key,
     () => {
-      changeTool(selectedLabelType, Tools.CLASSIFICATION);
+      setSelectedLabelId(null);
+      setSelectedTool(Tools.CLASSIFICATION);
     },
     {},
-    [changeTool, selectedLabelType]
+    [setSelectedTool, setSelectedLabelId]
   );
   useHotkeys(
     keymap.toolBoundingBox.key,
     () => {
-      changeTool(selectedLabelType, Tools.BOX);
+      setSelectedLabelId(null);
+      setSelectedTool(Tools.BOX);
     },
     {},
-    [changeTool, selectedLabelType]
+    [setSelectedTool, setSelectedLabelId]
   );
   useHotkeys(
     keymap.toolPolygon.key,
     () => {
-      changeTool(selectedLabelType, Tools.POLYGON);
+      setSelectedLabelId(null);
+      setSelectedTool(Tools.POLYGON);
     },
     {},
-    [changeTool, selectedLabelType]
+    [setSelectedTool, setSelectedLabelId]
   );
   useHotkeys(
     keymap.toolIog.key,
     () => {
       if (process.env.NEXT_PUBLIC_IOG_API_ENDPOINT) {
-        changeTool(selectedLabelType, Tools.IOG);
+        setSelectedLabelId(null);
+        setSelectedTool(Tools.IOG);
       }
     },
     {},
-    [changeTool, selectedLabelType]
+    [setSelectedTool, setSelectedLabelId]
   );
   return (
     <Popover
@@ -301,7 +277,10 @@ export const DrawingTool = () => {
           e.stopPropagation();
         }}
         selectedTool={selectedTool}
-        setSelectedTool={(tool: Tools) => changeTool(selectedLabelType, tool)}
+        setSelectedTool={(tool: Tools) => {
+          setSelectedLabelId(null);
+          setSelectedTool(tool);
+        }}
       />
       <PopoverContent
         borderColor={mode("gray.200", "gray.600")}
@@ -317,7 +296,8 @@ export const DrawingTool = () => {
               shortcut={keymap.toolClassification.key}
               selected={selectedTool === Tools.CLASSIFICATION}
               onClick={() => {
-                changeTool(selectedLabelType, Tools.CLASSIFICATION);
+                setSelectedLabelId(null);
+                setSelectedTool(Tools.CLASSIFICATION);
                 setIsPopoverOpened(false);
               }}
               ariaLabel="Classification tool"
@@ -331,7 +311,8 @@ export const DrawingTool = () => {
               shortcut={keymap.toolBoundingBox.key}
               selected={selectedTool === Tools.BOX}
               onClick={() => {
-                changeTool(selectedLabelType, Tools.BOX);
+                setSelectedLabelId(null);
+                setSelectedTool(Tools.BOX);
                 setIsPopoverOpened(false);
               }}
               ariaLabel="Bounding box tool"
@@ -345,7 +326,8 @@ export const DrawingTool = () => {
               shortcut={keymap.toolPolygon.key}
               selected={selectedTool === Tools.POLYGON}
               onClick={() => {
-                changeTool(selectedLabelType, Tools.POLYGON);
+                setSelectedLabelId(null);
+                setSelectedTool(Tools.POLYGON);
                 setIsPopoverOpened(false);
               }}
               ariaLabel="Polygon tool"
@@ -360,7 +342,8 @@ export const DrawingTool = () => {
                 shortcut={keymap.toolIog.key}
                 selected={selectedTool === Tools.IOG}
                 onClick={() => {
-                  changeTool(selectedLabelType, Tools.IOG);
+                  setSelectedLabelId(null);
+                  setSelectedTool(Tools.IOG);
                   setIsPopoverOpened(false);
                 }}
                 ariaLabel="Select iog tool"

--- a/typescript/web/src/components/labeling-tool/drawing-tool-bar/drawing-tool.tsx
+++ b/typescript/web/src/components/labeling-tool/drawing-tool-bar/drawing-tool.tsx
@@ -222,10 +222,15 @@ export const DrawingTool = () => {
     }
   }, []);
 
+  useEffect(() => {
+    if (selectedTool !== Tools.SELECTION) {
+      setSelectedLabelId(null);
+    }
+  }, [selectedTool, setSelectedLabelId]);
+
   useHotkeys(
     keymap.toolClassification.key,
     () => {
-      setSelectedLabelId(null);
       setSelectedTool(Tools.CLASSIFICATION);
     },
     {},
@@ -234,7 +239,6 @@ export const DrawingTool = () => {
   useHotkeys(
     keymap.toolBoundingBox.key,
     () => {
-      setSelectedLabelId(null);
       setSelectedTool(Tools.BOX);
     },
     {},
@@ -243,7 +247,6 @@ export const DrawingTool = () => {
   useHotkeys(
     keymap.toolPolygon.key,
     () => {
-      setSelectedLabelId(null);
       setSelectedTool(Tools.POLYGON);
     },
     {},
@@ -253,7 +256,6 @@ export const DrawingTool = () => {
     keymap.toolIog.key,
     () => {
       if (process.env.NEXT_PUBLIC_IOG_API_ENDPOINT) {
-        setSelectedLabelId(null);
         setSelectedTool(Tools.IOG);
       }
     },
@@ -278,7 +280,6 @@ export const DrawingTool = () => {
         }}
         selectedTool={selectedTool}
         setSelectedTool={(tool: Tools) => {
-          setSelectedLabelId(null);
           setSelectedTool(tool);
         }}
       />
@@ -296,7 +297,6 @@ export const DrawingTool = () => {
               shortcut={keymap.toolClassification.key}
               selected={selectedTool === Tools.CLASSIFICATION}
               onClick={() => {
-                setSelectedLabelId(null);
                 setSelectedTool(Tools.CLASSIFICATION);
                 setIsPopoverOpened(false);
               }}
@@ -311,7 +311,6 @@ export const DrawingTool = () => {
               shortcut={keymap.toolBoundingBox.key}
               selected={selectedTool === Tools.BOX}
               onClick={() => {
-                setSelectedLabelId(null);
                 setSelectedTool(Tools.BOX);
                 setIsPopoverOpened(false);
               }}
@@ -326,7 +325,6 @@ export const DrawingTool = () => {
               shortcut={keymap.toolPolygon.key}
               selected={selectedTool === Tools.POLYGON}
               onClick={() => {
-                setSelectedLabelId(null);
                 setSelectedTool(Tools.POLYGON);
                 setIsPopoverOpened(false);
               }}
@@ -342,7 +340,6 @@ export const DrawingTool = () => {
                 shortcut={keymap.toolIog.key}
                 selected={selectedTool === Tools.IOG}
                 onClick={() => {
-                  setSelectedLabelId(null);
                   setSelectedTool(Tools.IOG);
                   setIsPopoverOpened(false);
                 }}

--- a/typescript/web/src/components/labeling-tool/openlayers-map/edit-label-class.tsx
+++ b/typescript/web/src/components/labeling-tool/openlayers-map/edit-label-class.tsx
@@ -291,16 +291,7 @@ export const EditLabelClass = forwardRef<
         const digit = Number(keyboardEvent.code[5]);
         const indexOfLabelClass = (digit + 9) % 10;
         if (indexOfLabelClass < labelClasses.length) {
-          perform(
-            createUpdateLabelClassOfLabelEffect(
-              {
-                selectedLabelId,
-                selectedLabelClassId: labelClasses[indexOfLabelClass]?.id,
-              },
-              { client }
-            )
-          );
-          onClose();
+          handleSelectedClassChange(labelClasses[indexOfLabelClass]);
         }
       }
     },


### PR DESCRIPTION
# Feature

## Work performed

- Enable to set classification class from shortcut
- Reset selected label when changing the selected tool to any drawing tool

## Results

![shortcuts](https://user-images.githubusercontent.com/17384901/136981988-583587a8-a10f-4e81-b3f3-2709e9c8f654.gif)

![select](https://user-images.githubusercontent.com/17384901/137344358-42fe3339-d9a2-427e-8401-6ba8ae4fadac.gif)


## Resolved issues

Closes #491 

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
