### PR TITLE
Redirect to last visited workspace

### DIFF
--- a/typescript/web/src/components/welcome-manager/welcome-modal.tsx
+++ b/typescript/web/src/components/welcome-manager/welcome-modal.tsx
@@ -170,6 +170,9 @@ export const WelcomeModal = ({
   const [{ tryDespiteBrowserWarning }, setTryDespiteBrowserWarning] =
     useCookies(["tryDespiteBrowserWarning"]);
 
+  const [{ lastVisitedWorkspaceSlug }, setLastVisitedWorkspaceSlug] =
+    useCookies(["lastVisitedWorkspaceSlug"]);
+
   const [browserWarning] = useState(() => {
     const name = browser?.name;
     const os = browser?.os;
@@ -268,6 +271,17 @@ export const WelcomeModal = ({
       });
     }
   }, [tryDespiteBrowserWarning, router?.isReady, router?.query?.workspaceSlug]);
+
+  // Set cookie of last visited workspace if the user navigated to a new workspace
+  useEffect(() => {
+    const workspaceSlug = router?.query?.workspaceSlug;
+    if (workspaceSlug != null && lastVisitedWorkspaceSlug !== workspaceSlug) {
+      setLastVisitedWorkspaceSlug("lastVisitedWorkspaceSlug", workspaceSlug, {
+        path: "/",
+        httpOnly: false,
+      });
+    }
+  }, [router?.query?.workspaceSlug]);
 
   // welcome => undefined
   const handleGetStarted = useCallback(() => {

--- a/typescript/web/src/pages/index.tsx
+++ b/typescript/web/src/pages/index.tsx
@@ -46,11 +46,13 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const parsedCookie = new Cookies(context.req.headers.cookie);
 
   if (parsedCookie.get("hasUserTriedApp") === "true") {
+    const workspaceSlug =
+      parsedCookie.get("lastVisitedWorkspaceSlug") ?? "local";
     return {
       props: {},
       redirect: {
         // Keep query params after redirect
-        destination: `/local/datasets${
+        destination: `/${workspaceSlug}/datasets${
           isEmpty(context.query)
             ? ""
             : `?${join(


### PR DESCRIPTION
# Feature

## Work performed

- Add a cookie that stores the slug of the last visited workspace
- Redirect to the last visited workspace when the user accesses the landing page

## Results

<!--- Does this MR fully implement the new feature? If not why? Create and link new issues. -->

## Problems encountered

<!--- Explain problems that were encountered when implementing this MR -->

## Caveats

<!--- Any particular attention point with what you did? -->

## Resolved issues

Closes #515 

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
