### PR TITLE
Feature/validate email address on signin modal

### DIFF
--- a/typescript/web/src/components/auth-manager/signin-modal/signin-modal.tsx
+++ b/typescript/web/src/components/auth-manager/signin-modal/signin-modal.tsx
@@ -23,6 +23,7 @@ import { FaGithub, FaGoogle } from "react-icons/fa";
 import { DividerWithText } from "./divider-with-text";
 import { Logo } from "../../logo";
 import { Features } from "./features";
+import { validateEmail } from "../../../utils/validate-email";
 
 const errors = {
   Signin: "Try signing in with a different account.",
@@ -57,6 +58,8 @@ export const SigninModal = ({
   setLinkSent: (email: string) => void;
 }) => {
   const [sendingLink, setSendingLink] = useState(false);
+  const [isEmailInvalid, setIsEmailInvalid] =
+    useState<boolean | undefined>(undefined);
 
   const performSignIn = useCallback(
     async (method, options = {}) => {
@@ -140,6 +143,9 @@ export const SigninModal = ({
 
               <DividerWithText>or sign in with email</DividerWithText>
               <form
+                css={{
+                  ":invalid": { button: { color: "red" } },
+                }}
                 onSubmit={(e) => {
                   e.preventDefault();
                   const email = (
@@ -161,8 +167,25 @@ export const SigninModal = ({
                     </>
                   ) : (
                     <>
-                      <FormControl id="email">
+                      <FormControl
+                        id="email"
+                        isRequired
+                        isInvalid={isEmailInvalid}
+                      >
                         <Input
+                          onChange={(event) => {
+                            setIsEmailInvalid(
+                              !validateEmail(event.target.value)
+                            );
+                          }}
+                          onBlur={(event) => {
+                            if (event.target.value.length === 0) {
+                              setIsEmailInvalid(undefined);
+                            }
+                          }}
+                          focusBorderColor={
+                            isEmailInvalid ? "red.500" : undefined
+                          }
                           type="email"
                           autoComplete="email"
                           placeholder="you@company.com"
@@ -171,6 +194,7 @@ export const SigninModal = ({
                       <Button
                         type="submit"
                         variant="outline"
+                        isDisabled={isEmailInvalid ?? true}
                         leftIcon={<Box as={RiMailSendLine} color="brand.500" />}
                         isLoading={sendingLink}
                         loadingText="Submitting"

--- a/typescript/web/src/components/auth-manager/signin-modal/signin-modal.tsx
+++ b/typescript/web/src/components/auth-manager/signin-modal/signin-modal.tsx
@@ -143,9 +143,6 @@ export const SigninModal = ({
 
               <DividerWithText>or sign in with email</DividerWithText>
               <form
-                css={{
-                  ":invalid": { button: { color: "red" } },
-                }}
                 onSubmit={(e) => {
                   e.preventDefault();
                   const email = (

--- a/typescript/web/src/components/auth-manager/signin-modal/signin-modal.tsx
+++ b/typescript/web/src/components/auth-manager/signin-modal/signin-modal.tsx
@@ -170,9 +170,16 @@ export const SigninModal = ({
                         isInvalid={isEmailInvalid}
                       >
                         <Input
+                          onFocus={(event) => {
+                            setIsEmailInvalid(
+                              !validateEmail(event.target.value) ||
+                                event.target.value.length === 0
+                            );
+                          }}
                           onChange={(event) => {
                             setIsEmailInvalid(
-                              !validateEmail(event.target.value)
+                              !validateEmail(event.target.value) ||
+                                event.target.value.length === 0
                             );
                           }}
                           onBlur={(event) => {

--- a/typescript/web/src/components/auth-manager/signin-modal/signin-modal.tsx
+++ b/typescript/web/src/components/auth-manager/signin-modal/signin-modal.tsx
@@ -172,14 +172,16 @@ export const SigninModal = ({
                         <Input
                           onFocus={(event) => {
                             setIsEmailInvalid(
-                              !validateEmail(event.target.value) ||
-                                event.target.value.length === 0
+                              event.target.value.length === 0
+                                ? undefined
+                                : !validateEmail(event.target.value)
                             );
                           }}
                           onChange={(event) => {
                             setIsEmailInvalid(
-                              !validateEmail(event.target.value) ||
-                                event.target.value.length === 0
+                              event.target.value.length === 0
+                                ? undefined
+                                : !validateEmail(event.target.value)
                             );
                           }}
                           onBlur={(event) => {

--- a/typescript/web/src/components/members/new-member-modal.tsx
+++ b/typescript/web/src/components/members/new-member-modal.tsx
@@ -25,12 +25,8 @@ import { MembershipRole, InvitationResult } from "@labelflow/graphql-types";
 
 import { RoleSelection } from "./role-selection";
 import { InviteMember } from "./types";
+import { validateEmail } from "../../utils/validate-email";
 
-const validateEmail = (email: string): boolean => {
-  const re =
-    /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-  return re.test(String(email).toLowerCase());
-};
 const maxNumberOfEmails = 20;
 type EmailStatuses = Record<InvitationResult, string[]>;
 

--- a/typescript/web/src/utils/validate-email.tsx
+++ b/typescript/web/src/utils/validate-email.tsx
@@ -1,0 +1,5 @@
+export const validateEmail = (email: string): boolean => {
+  const re =
+    /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+  return re.test(String(email).toLowerCase());
+};


### PR DESCRIPTION
# Feature

## Work performed

Add email validation on sign-in modal

## Results

- Button is disabled when empty
![image](https://user-images.githubusercontent.com/2271940/141810452-d27c202c-6031-44f8-a0c8-a8ce5799efa2.png)

- Button is enabled and focus is blue when valid
![image](https://user-images.githubusercontent.com/2271940/141810599-d11838ae-5c37-4697-9b1e-ad9c814afa4b.png)

- Border is grey when valid and unfocused
![image](https://user-images.githubusercontent.com/2271940/141810687-1ebfbe7a-649b-4ec9-941a-59ccc33ff979.png)

- Button is disabled and border is red (when focused and unfocused) when invalid email (and not empty)
![image](https://user-images.githubusercontent.com/2271940/141810815-8e918bc1-b161-4898-a285-2f90f68421db.png)

## Problems encountered

Chakra doesn't really let you use native `:valid` and `:invalid` CSS selectors without re-implementing all chakra styling. So, we have to keep a react state to handle this :/

## Resolved issues

#575 
