### PR TITLE
Replace usage of external url env var by hardcoded url for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,11 +116,11 @@ jobs:
       - name: generate prisma
         run: cd typescript/db && yarn deploy && yarn generate
         env:
-          POSTGRES_EXTERNAL_URL: ${{secrets.POSTGRES_EXTERNAL_URL}}
+          POSTGRES_EXTERNAL_URL: postgresql://admin:admin@localhost:5433/labelflow?schema=public
       - name: run tests
         run: yarn test
         env:
-          POSTGRES_EXTERNAL_URL: ${{secrets.POSTGRES_EXTERNAL_URL}}
+          POSTGRES_EXTERNAL_URL: postgresql://admin:admin@localhost:5433/labelflow?schema=public
 
   check-codegen-diff:
     name: Check diff after codegen


### PR DESCRIPTION
# Feature

## Work performed

- Replaced the value for `POSTGRES_EXTERNAL_URL` in the tests action of the CI by a hardcoded value pointing to the DB in the container
