### PR TITLE
Change loading indicator tooltip when uploading files

### DIFF
--- a/typescript/web/src/components/import-button/import-images-modal/import-progress.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/import-progress.tsx
@@ -42,7 +42,7 @@ export const ImportProgress = ({ status }: { status: boolean | string }) => {
   }
 
   return (
-    <Tooltip label="Loading indicator" placement="left">
+    <Tooltip label="Upload in progress" placement="left">
       <span>
         <LoadingIcon
           display="inline-block"


### PR DESCRIPTION
# Feature

## Work performed

- Change loading indicator tooltip when uploading files

## Results

<img width="1104" alt="Screenshot 2021-11-17 at 17 53 26" src="https://user-images.githubusercontent.com/17384901/142255436-cd7c6b63-4f50-4547-a46d-c08b882b732e.png">

## Resolved issues

Closes #577 
