### PR TITLE
create dedicated isWorkspaceSlugAlreadyTaken resolver and use it on t…

### DIFF
--- a/data/__generated__/schema.graphql
+++ b/data/__generated__/schema.graphql
@@ -378,6 +378,7 @@ type Query {
   searchDataset(where: DatasetWhereUniqueInput!): Dataset
   workspace(where: WorkspaceWhereUniqueInput!): Workspace!
   workspaces(first: Int, skip: Int, where: WorkspaceWhereInput): [Workspace!]!
+  isWorkspaceSlugAlreadyTaken(where: WorkspaceWhereInput!): Boolean!
   membership(where: MembershipWhereUniqueInput!): Membership!
   memberships(where: MembershipWhereInput, first: Int, skip: Int): [Membership!]!
   user(where: UserWhereUniqueInput!): User!

--- a/data/queries.graphql
+++ b/data/queries.graphql
@@ -31,6 +31,7 @@ type Query {
 
   workspace(where: WorkspaceWhereUniqueInput!): Workspace!
   workspaces(first: Int, skip: Int, where: WorkspaceWhereInput): [Workspace!]!
+  isWorkspaceSlugAlreadyTaken(where: WorkspaceWhereInput!): Boolean!
 
   membership(where: MembershipWhereUniqueInput!): Membership!
   memberships(

--- a/typescript/db/src/__generated__/schema.ts
+++ b/typescript/db/src/__generated__/schema.ts
@@ -380,6 +380,7 @@ export const typeDefs = [
     searchDataset(where: DatasetWhereUniqueInput!): Dataset
     workspace(where: WorkspaceWhereUniqueInput!): Workspace!
     workspaces(first: Int, skip: Int, where: WorkspaceWhereInput): [Workspace!]!
+    isWorkspaceSlugAlreadyTaken(where: WorkspaceWhereInput!): Boolean!
     membership(where: MembershipWhereUniqueInput!): Membership!
     memberships(where: MembershipWhereInput, first: Int, skip: Int): [Membership!]!
     user(where: UserWhereUniqueInput!): User!

--- a/typescript/db/src/resolvers/workspace.ts
+++ b/typescript/db/src/resolvers/workspace.ts
@@ -50,6 +50,24 @@ const workspace = async (
 ): Promise<DbWorkspaceWithType> =>
   await getWorkspace(args.where, repository, user);
 
+const isWorkspaceSlugAlreadyTaken = async (
+  _: any,
+  args: QueryWorkspaceArgs,
+  { repository, user }: Context
+): Promise<boolean> => {
+  try {
+    return (await repository.workspace.get(args.where, user)) != null;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes("User not authorized to access workspace")
+    ) {
+      return true;
+    }
+    throw error;
+  }
+};
+
 const workspaces = async (
   _: any,
   args: QueryWorkspacesArgs,
@@ -222,6 +240,7 @@ export default {
   Query: {
     workspace,
     workspaces,
+    isWorkspaceSlugAlreadyTaken,
   },
   Mutation: { createWorkspace, updateWorkspace },
   Workspace: { memberships, datasets, stripeCustomerPortalUrl },

--- a/typescript/graphql-types/src/graphql-types.generated.ts
+++ b/typescript/graphql-types/src/graphql-types.generated.ts
@@ -552,6 +552,7 @@ export type Query = {
   searchDataset?: Maybe<Dataset>;
   workspace: Workspace;
   workspaces: Array<Workspace>;
+  isWorkspaceSlugAlreadyTaken: Scalars['Boolean'];
   membership: Membership;
   memberships: Array<Membership>;
   user: User;
@@ -636,6 +637,11 @@ export type QueryWorkspacesArgs = {
   first?: Maybe<Scalars['Int']>;
   skip?: Maybe<Scalars['Int']>;
   where?: Maybe<WorkspaceWhereInput>;
+};
+
+
+export type QueryIsWorkspaceSlugAlreadyTakenArgs = {
+  where: WorkspaceWhereInput;
 };
 
 
@@ -1174,6 +1180,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   searchDataset?: Resolver<Maybe<ResolversTypes['Dataset']>, ParentType, ContextType, RequireFields<QuerySearchDatasetArgs, 'where'>>;
   workspace?: Resolver<ResolversTypes['Workspace'], ParentType, ContextType, RequireFields<QueryWorkspaceArgs, 'where'>>;
   workspaces?: Resolver<Array<ResolversTypes['Workspace']>, ParentType, ContextType, RequireFields<QueryWorkspacesArgs, never>>;
+  isWorkspaceSlugAlreadyTaken?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<QueryIsWorkspaceSlugAlreadyTakenArgs, 'where'>>;
   membership?: Resolver<ResolversTypes['Membership'], ParentType, ContextType, RequireFields<QueryMembershipArgs, 'where'>>;
   memberships?: Resolver<Array<ResolversTypes['Membership']>, ParentType, ContextType, RequireFields<QueryMembershipsArgs, never>>;
   user?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<QueryUserArgs, 'where'>>;

--- a/typescript/web/src/components/settings/workspace/profile.tsx
+++ b/typescript/web/src/components/settings/workspace/profile.tsx
@@ -18,7 +18,7 @@ import { RiGroupFill } from "react-icons/ri";
 import { useRouter } from "next/router";
 import {
   Message,
-  searchWorkspacesQuery,
+  isWorkspaceSlugAlreadyTakenQuery,
 } from "../../workspace-switcher/workspace-creation-modal";
 import { randomBackgroundGradient } from "../../../utils/random-background-gradient";
 import { FieldGroup, HeadingGroup, Card } from "..";
@@ -104,13 +104,14 @@ export const Profile = ({
    * This query and the following mutation need to run against the distant database endpoint;
    * This is currently enforced in the TopBar component.
    */
-  const { data } = useQuery(searchWorkspacesQuery, {
+  const { data } = useQuery(isWorkspaceSlugAlreadyTakenQuery, {
     skip: workspaceName === workspace?.name ?? "",
     variables: { slug },
     fetchPolicy: "network-only",
   });
 
-  const workspaceNameIsAlreadyTaken = data?.workspaces?.length === 1;
+  const isWorkspaceSlugAlreadyTaken =
+    data?.isWorkspaceSlugAlreadyTaken ?? false;
 
   const avatarBorderColor = mode("gray.200", "gray.700");
   const avatarBackground = mode("white", "gray.700");
@@ -164,7 +165,7 @@ export const Profile = ({
             isOnlyDisplaying={workspaceName === workspace?.name}
             error={error}
             workspaceName={workspaceName}
-            workspaceNameIsAlreadyTaken={workspaceNameIsAlreadyTaken}
+            isWorkspaceSlugAlreadyTaken={isWorkspaceSlugAlreadyTaken}
           />
           <Box flexDirection="row" alignSelf="flex-end">
             <Button

--- a/typescript/web/src/components/workspace-switcher/workspace-creation-modal/__tests__/index.tsx
+++ b/typescript/web/src/components/workspace-switcher/workspace-creation-modal/__tests__/index.tsx
@@ -24,7 +24,7 @@ describe("Message", () => {
       <Message
         error={undefined}
         workspaceName="test"
-        workspaceNameIsAlreadyTaken={false}
+        isWorkspaceSlugAlreadyTaken={false}
       />
     );
     expect(
@@ -37,7 +37,7 @@ describe("Message", () => {
       <Message
         error={undefined}
         workspaceName="test"
-        workspaceNameIsAlreadyTaken
+        isWorkspaceSlugAlreadyTaken
       />
     );
     expect(getByText(/The name "test" is already taken/)).toBeDefined();
@@ -48,7 +48,7 @@ describe("Message", () => {
       <Message
         error={undefined}
         workspaceName={forbiddenWorkspaceSlugs[0]}
-        workspaceNameIsAlreadyTaken={false}
+        isWorkspaceSlugAlreadyTaken={false}
       />
     );
     expect(getByText(/The name ".*?" is already taken/)).toBeDefined();
@@ -59,7 +59,7 @@ describe("Message", () => {
       <Message
         error={undefined}
         workspaceName="hello!"
-        workspaceNameIsAlreadyTaken={false}
+        isWorkspaceSlugAlreadyTaken={false}
       />
     );
     expect(
@@ -72,7 +72,7 @@ describe("Message", () => {
       <Message
         error={new ApolloError({ errorMessage: "this is an error" })}
         workspaceName="test"
-        workspaceNameIsAlreadyTaken={false}
+        isWorkspaceSlugAlreadyTaken={false}
       />
     );
     expect(getByText(/this is an error/)).toBeDefined();
@@ -83,7 +83,7 @@ describe("Message", () => {
       <Message
         error={undefined}
         workspaceName={undefined}
-        workspaceNameIsAlreadyTaken={false}
+        isWorkspaceSlugAlreadyTaken={false}
       />
     );
 

--- a/typescript/web/src/components/workspace-switcher/workspace-creation-modal/index.tsx
+++ b/typescript/web/src/components/workspace-switcher/workspace-creation-modal/index.tsx
@@ -28,11 +28,9 @@ import { Logo } from "../../logo";
 import { Features } from "../../auth-manager/signin-modal/features";
 import { BoolParam } from "../../../utils/query-param-bool";
 
-export const searchWorkspacesQuery = gql`
-  query searchWorkspaces($slug: String!) {
-    workspaces(first: 1, where: { slug: $slug }) {
-      id
-    }
+export const isWorkspaceSlugAlreadyTakenQuery = gql`
+  query isWorkspaceSlugAlreadyTaken($slug: String!) {
+    isWorkspaceSlugAlreadyTaken(where: { slug: $slug })
   }
 `;
 
@@ -48,12 +46,12 @@ export const createWorkspaceMutation = gql`
 export const Message = ({
   error,
   workspaceName,
-  workspaceNameIsAlreadyTaken,
+  isWorkspaceSlugAlreadyTaken,
   isOnlyDisplaying,
 }: {
   error: ApolloError | undefined;
   workspaceName: string | null | undefined;
-  workspaceNameIsAlreadyTaken: boolean;
+  isWorkspaceSlugAlreadyTaken: boolean;
   isOnlyDisplaying?: boolean;
 }) => {
   if (error) {
@@ -64,7 +62,7 @@ export const Message = ({
     );
   }
 
-  if (workspaceNameIsAlreadyTaken) {
+  if (isWorkspaceSlugAlreadyTaken) {
     return (
       <Text fontSize="sm" color="red.500">
         The name &quot;{workspaceName}&quot; is already taken
@@ -135,7 +133,7 @@ export const WorkspaceCreationModal = ({
    * This query and the following mutation need to run against the distant database endpoint;
    * This is currently enforced in the TopBar component.
    */
-  const { data } = useQuery(searchWorkspacesQuery, {
+  const { data } = useQuery(isWorkspaceSlugAlreadyTakenQuery, {
     skip: workspaceName === undefined,
     variables: { slug },
     fetchPolicy: "network-only",
@@ -174,7 +172,8 @@ export const WorkspaceCreationModal = ({
     },
   });
 
-  const workspaceNameIsAlreadyTaken = data?.workspaces?.length === 1;
+  const isWorkspaceSlugAlreadyTaken =
+    data?.isWorkspaceSlugAlreadyTaken ?? false;
 
   return (
     <Modal
@@ -225,9 +224,9 @@ export const WorkspaceCreationModal = ({
                   <Input
                     aria-label="workspace name input"
                     focusBorderColor={
-                      workspaceNameIsAlreadyTaken ? "red.500" : undefined
+                      isWorkspaceSlugAlreadyTaken ? "red.500" : undefined
                     }
-                    isInvalid={workspaceNameIsAlreadyTaken}
+                    isInvalid={isWorkspaceSlugAlreadyTaken}
                     placeholder="My online workspace name"
                     value={workspaceName ?? ""}
                     onChange={(event) => setWorkspaceName(event.target.value)}
@@ -235,14 +234,14 @@ export const WorkspaceCreationModal = ({
                   <Message
                     error={error}
                     workspaceName={workspaceName}
-                    workspaceNameIsAlreadyTaken={workspaceNameIsAlreadyTaken}
+                    isWorkspaceSlugAlreadyTaken={isWorkspaceSlugAlreadyTaken}
                   />
                 </Stack>
                 <Button
                   width="full"
                   type="submit"
                   isDisabled={
-                    workspaceNameIsAlreadyTaken ||
+                    isWorkspaceSlugAlreadyTaken ||
                     slug.length <= 0 ||
                     forbiddenWorkspaceSlugs.includes(slug) ||
                     !isValidWorkspaceName(workspaceName ?? "")

--- a/typescript/web/src/components/workspace-switcher/workspace-creation-modal/index.tsx
+++ b/typescript/web/src/components/workspace-switcher/workspace-creation-modal/index.tsx
@@ -224,9 +224,17 @@ export const WorkspaceCreationModal = ({
                   <Input
                     aria-label="workspace name input"
                     focusBorderColor={
-                      isWorkspaceSlugAlreadyTaken ? "red.500" : undefined
+                      isWorkspaceSlugAlreadyTaken ||
+                      forbiddenWorkspaceSlugs.includes(slug) ||
+                      !isValidWorkspaceName(workspaceName ?? "")
+                        ? "red.500"
+                        : undefined
                     }
-                    isInvalid={isWorkspaceSlugAlreadyTaken}
+                    isInvalid={
+                      isWorkspaceSlugAlreadyTaken ||
+                      forbiddenWorkspaceSlugs.includes(slug) ||
+                      !isValidWorkspaceName(workspaceName ?? "")
+                    }
                     placeholder="My online workspace name"
                     value={workspaceName ?? ""}
                     onChange={(event) => setWorkspaceName(event.target.value)}

--- a/typescript/web/src/connectors/apollo-client/__generated__/schema.ts
+++ b/typescript/web/src/connectors/apollo-client/__generated__/schema.ts
@@ -381,6 +381,7 @@ export const typeDefs = gql`
     searchDataset(where: DatasetWhereUniqueInput!): Dataset
     workspace(where: WorkspaceWhereUniqueInput!): Workspace!
     workspaces(first: Int, skip: Int, where: WorkspaceWhereInput): [Workspace!]!
+    isWorkspaceSlugAlreadyTaken(where: WorkspaceWhereInput!): Boolean!
     membership(where: MembershipWhereUniqueInput!): Membership!
     memberships(where: MembershipWhereInput, first: Int, skip: Int): [Membership!]!
     user(where: UserWhereUniqueInput!): User!

--- a/typescript/web/src/connectors/resolvers/workspace.ts
+++ b/typescript/web/src/connectors/resolvers/workspace.ts
@@ -27,6 +27,7 @@ export default {
   Query: {
     workspace,
     workspaces,
+    isWorkspaceSlugAlreadyTaken: notImplementedInLocalWorkspaceRepository,
   },
 
   Mutation: {

--- a/typescript/web/src/worker/__generated__/schema.ts
+++ b/typescript/web/src/worker/__generated__/schema.ts
@@ -380,6 +380,7 @@ export const typeDefs = [
     searchDataset(where: DatasetWhereUniqueInput!): Dataset
     workspace(where: WorkspaceWhereUniqueInput!): Workspace!
     workspaces(first: Int, skip: Int, where: WorkspaceWhereInput): [Workspace!]!
+    isWorkspaceSlugAlreadyTaken(where: WorkspaceWhereInput!): Boolean!
     membership(where: MembershipWhereUniqueInput!): Membership!
     memberships(where: MembershipWhereInput, first: Int, skip: Int): [Membership!]!
     user(where: UserWhereUniqueInput!): User!


### PR DESCRIPTION
# Feature

## Work performed

- Created a new query resolver named `isWorkspaceSlugAlreadyTaken`. It returns a boolean. The purpose is to avoid making the entire workspaces public.
- Swapped the query used in the workspace creation modal and replaced it with the newly created one.

## Results

Now, you get a proper warning which prevents you from creating a workspace with an already taken slug.

However, it doesn't solve the original bug which was that you get asked to sign in if the query fails.
I think this should be done in a deeper refactor regarding error handling in general. See https://github.com/labelflow/labelflow/issues/551#issuecomment-960700298

## Problems encountered

Permissions were not really clearly defined here. I implemented what I think is the safest solution but you can now know if a workspace name already exists. 

## Resolved issues

#582

## Newly raised issues

Not new, but relates to https://github.com/labelflow/labelflow/issues/551#issuecomment-960700298
