### PR TITLE
Bug/fix facebook article preview

### DIFF
--- a/typescript/web/src/components/meta.tsx
+++ b/typescript/web/src/components/meta.tsx
@@ -49,6 +49,7 @@ export const Meta = ({
         site: "@LabelflowAI",
         cardType: "summary_large_image",
       }}
+      facebook={{ appId: "461943602167313" }}
     />
     <Head>
       <link rel="icon" href="/static/favicon.ico" />

--- a/typescript/web/src/components/meta.tsx
+++ b/typescript/web/src/components/meta.tsx
@@ -45,8 +45,8 @@ export const Meta = ({
         images,
       }}
       twitter={{
-        handle: "@VLecrubier",
-        site: "@VLecrubier",
+        handle: "@LabelflowAI",
+        site: "@LabelflowAI",
         cardType: "summary_large_image",
       }}
     />


### PR DESCRIPTION
# Feature

## Work performed

- Added Facebook app id. It seems to display the correct preview now.
- Update twitter SEO params to point to LabelFlow's one instead of Vincent's one.

## Results

https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Flabelflow-git-bug-fix-facebook-article-preview-labelflow.vercel.app%2Fposts%2Fai-metrics-image-classification

![image](https://user-images.githubusercontent.com/2271940/143566515-2973d948-6700-46aa-b557-cb39630f43ff.png)

Cute cat BTW 😻 

## Resolved issues

closes #612
