### PR TITLE
fix user invitation urls

### DIFF
--- a/typescript/db/src/resolvers/invite-member.ts
+++ b/typescript/db/src/resolvers/invite-member.ts
@@ -111,7 +111,7 @@ const inviteMember = async (
   try {
     const result = await fetch(
       `${origin}/api/email/send-invitation?${searchParams.toString()}`,
-      { headers: { cookie: (req?.headers as any).cookie } }
+      { headers: { cookie: (req?.headers as any).cookie, origin } }
     );
     if (result.status !== 200) {
       throw new Error(`Not signed in.`);

--- a/typescript/web/src/pages/api/email/send-invitation.ts
+++ b/typescript/web/src/pages/api/email/send-invitation.ts
@@ -36,7 +36,12 @@ export default async function handler(
       membershipId,
     });
 
-    const origin = process.env.VERCEL_URL ?? "https://labelflow.ai";
+    // We use the NEXTAUTH_URL on the production deployment only
+    // Vercel_URL is different on each deployment (=== commit)
+    const origin =
+      process.env.NEXTAUTH_URL ||
+      process.env.VERCEL_URL ||
+      "https://labelflow.ai";
     const url = `${origin}/${workspaceSlug}/accept-invite?${searchParams.toString()}`;
     const transport = createTransport(process.env.EMAIL_SERVER ?? "");
     await transport.sendMail({

--- a/typescript/web/src/pages/api/email/send-invitation.ts
+++ b/typescript/web/src/pages/api/email/send-invitation.ts
@@ -36,12 +36,12 @@ export default async function handler(
       membershipId,
     });
 
-    // We use the NEXTAUTH_URL on the production deployment only
-    // Vercel_URL is different on each deployment (=== commit)
     const origin =
-      process.env.NEXTAUTH_URL ||
+      (req?.headers?.origin as string | undefined) ||
+      process.env.NEXTAUTH_URL || // We use the NEXTAUTH_URL on the production deployments only
       process.env.VERCEL_URL ||
       "https://labelflow.ai";
+
     const url = `${origin}/${workspaceSlug}/accept-invite?${searchParams.toString()}`;
     const transport = createTransport(process.env.EMAIL_SERVER ?? "");
     await transport.sendMail({


### PR DESCRIPTION
# Feature

## Work performed

- The inviteUser resolver now forwards the origin header to the API route `email/send-invitation`.
- The API route `email/send-invitation` now use the origin from the header if it is available.

## Results

Now, **invite emails** will correctly direct you to the URL origin that triggered the invite (even on dev branches).
This partially solves the original issue. At least, **it should never happen in production** as the URL origin doesn't change.

However, **this doesn't fix the magic link** ... It still uses the VERCEL_URL env var. And this one is provided by Vercel and changes at every commit. Vercel doesn't provide an env var for the related preview URL (which is shared across all the deployments of a PR)...
If for a particular reason, you want to use the preview URL, you can copy the end of the path you received in the magic link, and append it to the URL of the preview (PR) deployment.

## Caveats

In addition, **this doesn't fix the source problem** which is that you can't fetch an image that doesn't have the same origin as the page you are on.
The reason is simple, we use cookie-based authentication to access the images:

if you are on `abc.labelflow.ai` and you try to access `abc.labelflow.ai/uploads/123` what happens under the hood is that the client performs a request to the backend. In this request, the client adds the authentication cookie. 
The backend receives the request. It checks that the user is logged in using the cookie it has received
If the user is logged in, then it creates a temporary signed url and redirects the client to this url.
If the user isn't logged in, it returns a 401 - Unauthenticated error.
(BTW we could make this check more strict and verify that the user has access to this image). 

Now imagine you are on `def.labelflow.ai` and you try to access `abc.labelflow.ai/uploads/123`. And let's say that you are correctly authenticated on `def.labelflow.ai`. When the client does the request to `abc.labelflow.ai/uploads/123` this request can't be properly authenticated with a cookie because it is not possible to use `def.labelflow.ai`'s cookie on `abc.labelflow.ai`. The browser won't let you do this. It would be a major security leak to send your auth cookie to another website. And even if you are also logged in on `abc.labelflow.ai`, doing a request from `def.labelflow.ai` can't attach the cookie from `abc.labelflow.ai` for the same exact reason. The browser doesn't let you share cookies on 2 different origins.

TLDR: When on `abc.labelflow.ai`, it is not possible to be performed an authenticated request to any other LabelFlow subdomains. And you need to be authenticated to view images.

Once again, this is only a problem if we use different subdomains. But, as of today, this can only happen on development branches sharing the same database. 

## Resolved issues

#617 

