### PR TITLE
Increase IOG size limit

### DIFF
--- a/typescript/web/src/pages/api/graphql.ts
+++ b/typescript/web/src/pages/api/graphql.ts
@@ -63,3 +63,11 @@ const handleRequest: NextApiHandler = async (req, res) => {
 };
 
 export default handleRequest;
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: "10mb",
+    },
+  },
+};


### PR DESCRIPTION
# Feature

## Work performed

- Increased the `bodyParser` size limit of the Graphql API route as per the [Vercel docs](https://nextjs.org/docs/api-routes/api-middlewares#custom-config)

## Resolved issues

Closes #609
