### PR TITLE
Set correct value for `og:url` of articles

### DIFF
--- a/typescript/web/src/components/meta.tsx
+++ b/typescript/web/src/components/meta.tsx
@@ -1,13 +1,14 @@
 import * as React from "react";
 import { NextSeo } from "next-seo";
 import Head from "next/head";
-import { OpenGraphImages } from "next-seo/lib/types";
+import { OpenGraph } from "next-seo/lib/types";
 
 type Props = {
   title?: string;
   desc?: string;
   canonical?: string;
-  images?: OpenGraphImages[];
+  images?: OpenGraph["images"];
+  article?: OpenGraph["article"];
 };
 
 const defaultImages = [
@@ -30,6 +31,7 @@ export const Meta = ({
   desc = "The fastest and simplest image labeling tool on the Internet!",
   canonical = "https://labelflow.ai/",
   images = defaultImages,
+  article,
 }: Props) => (
   <>
     <NextSeo
@@ -37,12 +39,13 @@ export const Meta = ({
       description={desc}
       canonical={canonical}
       openGraph={{
-        type: "website",
+        type: article ? "article" : "website",
         url: canonical,
         title,
         description: desc,
         locale: "en_US",
         images,
+        article,
       }}
       twitter={{
         handle: "@LabelflowAI",

--- a/typescript/web/src/constants.ts
+++ b/typescript/web/src/constants.ts
@@ -1,0 +1,4 @@
+export const WEB_APP_URL_ORIGIN =
+  process.env.NEXTAUTH_URL ??
+  (process.env.VERCEL_URL && `https://${process.env.VERCEL_URL}`) ??
+  "https://labelflow.com";

--- a/typescript/web/src/pages/posts/[slug].tsx
+++ b/typescript/web/src/pages/posts/[slug].tsx
@@ -16,13 +16,9 @@ import { PostTitle } from "../../components/website/Blog/PostTitle";
 import "github-markdown-css";
 import { ServiceWorkerManagerBackground } from "../../components/service-worker-manager";
 import { CookieBanner } from "../../components/cookie-banner";
+import { WEB_APP_URL_ORIGIN } from "../../constants";
 
 const ChakraReactMarkdown = chakra(ReactMarkdown);
-
-const origin =
-  process.env.NEXTAUTH_URL ??
-  (process.env.VERCEL_URL && `https://${process.env.VERCEL_URL}`) ??
-  "https://labelflow.com";
 
 export default function Posts({
   article,
@@ -47,7 +43,7 @@ export default function Posts({
               ]
             : undefined
         }
-        canonical={`${origin}/posts/${article?.slug}`}
+        canonical={`${WEB_APP_URL_ORIGIN}/posts/${article?.slug}`}
         article={{
           authors: article?.author?.name ? [article?.author?.name] : [],
           publishedTime: article?.published_at,

--- a/typescript/web/src/pages/posts/[slug].tsx
+++ b/typescript/web/src/pages/posts/[slug].tsx
@@ -48,6 +48,11 @@ export default function Posts({
             : undefined
         }
         canonical={`${origin}/posts/${article?.slug}`}
+        article={{
+          authors: [article?.author?.name],
+          publishedTime: article?.published_at,
+          section: article?.category?.name,
+        }}
       />
       <CookieBanner />
       <Box minH="640px">

--- a/typescript/web/src/pages/posts/[slug].tsx
+++ b/typescript/web/src/pages/posts/[slug].tsx
@@ -19,6 +19,11 @@ import { CookieBanner } from "../../components/cookie-banner";
 
 const ChakraReactMarkdown = chakra(ReactMarkdown);
 
+const origin =
+  process.env.NEXTAUTH_URL ??
+  (process.env.VERCEL_URL && `https://${process.env.VERCEL_URL}`) ??
+  "https://labelflow.com";
+
 export default function Posts({
   article,
   moreArticles,
@@ -42,6 +47,7 @@ export default function Posts({
               ]
             : undefined
         }
+        canonical={`${origin}/posts/${article?.slug}`}
       />
       <CookieBanner />
       <Box minH="640px">

--- a/typescript/web/src/pages/posts/[slug].tsx
+++ b/typescript/web/src/pages/posts/[slug].tsx
@@ -49,7 +49,7 @@ export default function Posts({
         }
         canonical={`${origin}/posts/${article?.slug}`}
         article={{
-          authors: [article?.author?.name],
+          authors: article?.author?.name ? [article?.author?.name] : [],
           publishedTime: article?.published_at,
           section: article?.category?.name,
         }}


### PR DESCRIPTION
# Feature

## Work performed

Fixed image preview on Facebook. 

The fix on https://github.com/labelflow/labelflow/pull/616 was only working for Vercel preview deployments, it wasn't working on prod.

To fix this, I had to specify a correct value for `og:url`. 
By default, it was always pointing to `labelflow.ai`, from what I've read (I'm not the most experienced on this part) it has o point toward the URL of the article itself.

I also added a few meta tags specific to articles on the `/posts/[slug]` url.

## Results

Now I hope it works as expected, it should, but to make sure this is working, we have to deploy it on labelflow.ai

## Problems encountered

The behaviour was different between branch deployments and prod because we put a default `og:url` value to `labelflow.ai`, as explained on Facebook documentation [here](https://developers.facebook.com/docs/sharing/webmasters/getting-started/versioned-link/), cross domains references are ignored unless they have been approved on the admin dashboard.
