### PR TITLE
Add spinner on loading datasets and add reusable card box component

### DIFF
--- a/typescript/web/src/components/datasets/dataset-card-box.tsx
+++ b/typescript/web/src/components/datasets/dataset-card-box.tsx
@@ -1,0 +1,13 @@
+import { Box } from "@chakra-ui/react";
+import { ReactNode } from "react";
+
+export const DatasetCardBox = ({ children }: { children: ReactNode }) => (
+  <Box
+    w="100%"
+    maxWidth={["100%", "100%", "50%", "33%", "25%"]}
+    boxSizing="border-box"
+    p={4}
+  >
+    {children}
+  </Box>
+);

--- a/typescript/web/src/components/datasets/dataset-card.tsx
+++ b/typescript/web/src/components/datasets/dataset-card.tsx
@@ -13,6 +13,7 @@ import {
 } from "@chakra-ui/react";
 import NextLink from "next/link";
 import { HiTrash, HiPencilAlt } from "react-icons/hi";
+import { DatasetCardBox } from "./dataset-card-box";
 import { ImageWithFallback } from "../image";
 import { EmptyStateImageNotFound, EmptyStateNoImages } from "../empty-state";
 
@@ -44,12 +45,7 @@ export const DatasetCard = (props: {
 
   // This card is flexible, so its width will depend on the width of its parent
   return (
-    <Box
-      w="100%"
-      maxWidth={["100%", "100%", "50%", "33%", "25%"]}
-      p={4}
-      boxSizing="border-box"
-    >
+    <DatasetCardBox>
       <NextLink href={url}>
         <Box
           as="a"
@@ -130,6 +126,6 @@ export const DatasetCard = (props: {
           </VStack>
         </Box>
       </NextLink>
-    </Box>
+    </DatasetCardBox>
   );
 };

--- a/typescript/web/src/components/datasets/index.ts
+++ b/typescript/web/src/components/datasets/index.ts
@@ -1,4 +1,5 @@
 import { DatasetCard } from "./dataset-card";
 import { NewDatasetCard } from "./new-dataset-card";
+import { DatasetCardBox } from "./dataset-card-box";
 
-export { DatasetCard, NewDatasetCard };
+export { DatasetCard, NewDatasetCard, DatasetCardBox };

--- a/typescript/web/src/components/datasets/new-dataset-card.tsx
+++ b/typescript/web/src/components/datasets/new-dataset-card.tsx
@@ -1,5 +1,6 @@
-import { Flex, Text, chakra, Box } from "@chakra-ui/react";
+import { Flex, Text, chakra } from "@chakra-ui/react";
 import { FaPlus } from "react-icons/fa";
+import { DatasetCardBox } from "./dataset-card-box";
 
 const PlusIcon = chakra(FaPlus);
 
@@ -11,12 +12,7 @@ export const NewDatasetCard = (props: {
 
   // This card is flexible, so its width will depend on the width of its parent
   return (
-    <Box
-      w="100%"
-      maxWidth={["100%", "100%", "50%", "33%", "25%"]}
-      boxSizing="border-box"
-      p={4}
-    >
+    <DatasetCardBox>
       <Flex
         w="100%"
         h="2xs"
@@ -38,6 +34,6 @@ export const NewDatasetCard = (props: {
           Create new dataset...
         </Text>
       </Flex>
-    </Box>
+    </DatasetCardBox>
   );
 };

--- a/typescript/web/src/components/layout/tab-bar/tab-bar.tsx
+++ b/typescript/web/src/components/layout/tab-bar/tab-bar.tsx
@@ -67,7 +67,7 @@ export const TabBar = ({ tabs }: Props) => {
     >
       {tabs.map(({ name, url, isActive }) => {
         if (workspaceSlug === "local" && name === "settings") {
-          return <DisabledSettingsLink />;
+          return <DisabledSettingsLink key="settings" />;
         }
 
         return (

--- a/typescript/web/src/pages/[workspaceSlug]/datasets/index.tsx
+++ b/typescript/web/src/pages/[workspaceSlug]/datasets/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import { gql, useQuery } from "@apollo/client";
 
-import { Flex, Text } from "@chakra-ui/react";
+import { Flex, Text, Spinner } from "@chakra-ui/react";
 
 import { useQueryParam } from "use-query-params";
 
@@ -10,7 +10,11 @@ import { useRouter } from "next/router";
 import { Meta } from "../../../components/meta";
 import { Layout } from "../../../components/layout";
 import { IdParam, BoolParam } from "../../../utils/query-param-bool";
-import { NewDatasetCard, DatasetCard } from "../../../components/datasets";
+import {
+  NewDatasetCard,
+  DatasetCard,
+  DatasetCardBox,
+} from "../../../components/datasets";
 import { UpsertDatasetModal } from "../../../components/datasets/upsert-dataset-modal";
 import { DeleteDatasetModal } from "../../../components/datasets/delete-dataset-modal";
 import { ServiceWorkerManagerModal } from "../../../components/service-worker-manager";
@@ -45,13 +49,32 @@ export const getDatasetsQuery = gql`
   }
 `;
 
+const LoadingCard = () => (
+  <DatasetCardBox>
+    <Flex
+      w="100%"
+      h="2xs"
+      direction="column"
+      alignItems="center"
+      justify="center"
+    >
+      <Spinner
+        thickness="4px"
+        speed="0.65s"
+        emptyColor="gray.200"
+        color="#31CECA"
+        size="xl"
+      />
+    </Flex>
+  </DatasetCardBox>
+);
 const DatasetPage = () => {
   const {
     query: { workspaceSlug },
     isReady,
   } = useRouter();
 
-  const { data: datasetsResult } = useQuery<{
+  const { data: datasetsResult, loading } = useQuery<{
     datasets: Pick<
       DatasetType,
       | "id"
@@ -133,31 +156,35 @@ const DatasetPage = () => {
               setIsCreatingDataset(true, "replaceIn");
             }}
           />
-          {datasetsResult?.datasets?.map(
-            ({
-              id,
-              slug,
-              images,
-              name,
-              imagesAggregates,
-              labelsAggregates,
-              labelClassesAggregates,
-            }) => (
-              <DatasetCard
-                key={id}
-                url={`/${workspaceSlug}/datasets/${slug}`}
-                imageUrl={images[0]?.thumbnail500Url ?? undefined}
-                datasetName={name}
-                imagesCount={imagesAggregates.totalCount}
-                labelClassesCount={labelClassesAggregates.totalCount}
-                labelsCount={labelsAggregates.totalCount}
-                editDataset={() => {
-                  setEditDatasetId(id, "replaceIn");
-                }}
-                deleteDataset={() => {
-                  setDeleteDatasetId(id, "replaceIn");
-                }}
-              />
+          {loading ? (
+            <LoadingCard />
+          ) : (
+            datasetsResult?.datasets?.map(
+              ({
+                id,
+                slug,
+                images,
+                name,
+                imagesAggregates,
+                labelsAggregates,
+                labelClassesAggregates,
+              }) => (
+                <DatasetCard
+                  key={id}
+                  url={`/${workspaceSlug}/datasets/${slug}`}
+                  imageUrl={images[0]?.thumbnail500Url ?? undefined}
+                  datasetName={name}
+                  imagesCount={imagesAggregates.totalCount}
+                  labelClassesCount={labelClassesAggregates.totalCount}
+                  labelsCount={labelsAggregates.totalCount}
+                  editDataset={() => {
+                    setEditDatasetId(id, "replaceIn");
+                  }}
+                  deleteDataset={() => {
+                    setDeleteDatasetId(id, "replaceIn");
+                  }}
+                />
+              )
             )
           )}
         </Flex>


### PR DESCRIPTION
# Feature

## Work performed

- Add a spinner when the datasets are loading
- Add a reusable component wrapping the `NewDatasetCard`, the `DatasetCard` and the `LoadingCard` components
- Fix key error in tab bar

## Results

A spinner will be displayed when the datasets are loading
We can now use the `DatasetCardBox` component to obtain a flexible `Box` having the same size as the other "Cards". Modifying the `DatasetCardBox` component will update all 3 components quoted before

## Resolved issues

This PR will solve #627
This PR will close #653 
