### PR TITLE
COCO import bug fixes and improvements

### DIFF
--- a/typescript/common-resolvers/src/import/format-coco/__tests__/__snapshots__/converters.ts.snap
+++ b/typescript/common-resolvers/src/import/format-coco/__tests__/__snapshots__/converters.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`convertCocoSegmentationToLabel Should convert a box into a box 1`] = `
+exports[`convertGeometryFromCocoAnnotationToLabel Should convert a box into a box 1`] = `
 Object {
   "geometry": Object {
     "coordinates": Array [
@@ -33,7 +33,7 @@ Object {
 }
 `;
 
-exports[`convertCocoSegmentationToLabel Should convert a polygon into a polygon 1`] = `
+exports[`convertGeometryFromCocoAnnotationToLabel Should convert a polygon into a polygon 1`] = `
 Object {
   "geometry": Object {
     "coordinates": Array [
@@ -70,7 +70,7 @@ Object {
 }
 `;
 
-exports[`convertCocoSegmentationToLabel Should convert an empty segmentation's bounding box into a box 1`] = `
+exports[`convertGeometryFromCocoAnnotationToLabel Should convert an empty segmentation's bounding box into a box 1`] = `
 Object {
   "geometry": Object {
     "coordinates": Array [
@@ -80,16 +80,16 @@ Object {
           600,
         ],
         Array [
-          400,
-          600,
-        ],
-        Array [
-          400,
-          200,
-        ],
-        Array [
           100,
           200,
+        ],
+        Array [
+          400,
+          200,
+        ],
+        Array [
+          400,
+          600,
         ],
         Array [
           100,

--- a/typescript/common-resolvers/src/import/format-coco/__tests__/__snapshots__/converters.ts.snap
+++ b/typescript/common-resolvers/src/import/format-coco/__tests__/__snapshots__/converters.ts.snap
@@ -69,3 +69,36 @@ Object {
   "type": "Polygon",
 }
 `;
+
+exports[`convertCocoSegmentationToLabel Should convert an empty segmentation's bounding box into a box 1`] = `
+Object {
+  "geometry": Object {
+    "coordinates": Array [
+      Array [
+        Array [
+          100,
+          600,
+        ],
+        Array [
+          400,
+          600,
+        ],
+        Array [
+          400,
+          200,
+        ],
+        Array [
+          100,
+          200,
+        ],
+        Array [
+          100,
+          600,
+        ],
+      ],
+    ],
+    "type": "Polygon",
+  },
+  "type": "Box",
+}
+`;

--- a/typescript/common-resolvers/src/import/format-coco/__tests__/converters.ts
+++ b/typescript/common-resolvers/src/import/format-coco/__tests__/converters.ts
@@ -1,6 +1,6 @@
 import {
   isCocoSegmentationBox,
-  convertCocoSegmentationToLabel,
+  convertGeometryFromCocoAnnotationToLabel,
 } from "../converters";
 
 describe("isCocoSegmentationBox", () => {
@@ -60,10 +60,10 @@ describe("isCocoSegmentationBox", () => {
   });
 });
 
-describe("convertCocoSegmentationToLabel", () => {
+describe("convertGeometryFromCocoAnnotationToLabel", () => {
   test("Should convert a box into a box", () => {
     expect(
-      convertCocoSegmentationToLabel(
+      convertGeometryFromCocoAnnotationToLabel(
         [
           [
             123.33, 254.0001, 369.12346, 254.0005, 369.12348, 567.09436, 123.33,
@@ -77,12 +77,12 @@ describe("convertCocoSegmentationToLabel", () => {
   });
   test("Should convert an empty segmentation's bounding box into a box", () => {
     expect(
-      convertCocoSegmentationToLabel([], [100, 200, 300, 400], 700)
+      convertGeometryFromCocoAnnotationToLabel([], [100, 200, 300, 400], 700)
     ).toMatchSnapshot();
   });
   test("Should convert a polygon into a polygon", () => {
     expect(
-      convertCocoSegmentationToLabel(
+      convertGeometryFromCocoAnnotationToLabel(
         [
           [
             123.33, 254.0001, 369.12346, 254.0005, 369.12348, 567.09436, 123.33,

--- a/typescript/common-resolvers/src/import/format-coco/__tests__/converters.ts
+++ b/typescript/common-resolvers/src/import/format-coco/__tests__/converters.ts
@@ -14,6 +14,9 @@ describe("isCocoSegmentationBox", () => {
       ])
     ).toBeTruthy();
   });
+  test("Should consider an empty segmentation to a box, based on the bounding box", () => {
+    expect(isCocoSegmentationBox([])).toBeTruthy();
+  });
   test("Should discard segmentation with more than one polygon", () => {
     expect(
       isCocoSegmentationBox([
@@ -67,8 +70,14 @@ describe("convertCocoSegmentationToLabel", () => {
             567.09456, 123.33, 254.0001,
           ],
         ],
+        [0, 0, 568, 568],
         568
       )
+    ).toMatchSnapshot();
+  });
+  test("Should convert an empty segmentation's bounding box into a box", () => {
+    expect(
+      convertCocoSegmentationToLabel([], [100, 200, 300, 400], 700)
     ).toMatchSnapshot();
   });
   test("Should convert a polygon into a polygon", () => {
@@ -80,6 +89,7 @@ describe("convertCocoSegmentationToLabel", () => {
             567.09456, 100, 550, 123.33, 254.0001,
           ],
         ],
+        [0, 0, 568, 568],
         568
       )
     ).toMatchSnapshot();

--- a/typescript/common-resolvers/src/import/format-coco/converters.ts
+++ b/typescript/common-resolvers/src/import/format-coco/converters.ts
@@ -50,7 +50,7 @@ export const isCocoSegmentationBox = (
   return xValues.size === 2 && yValues.size === 2 && !polygonIsDegenerate;
 };
 
-export const convertCocoSegmentationToLabel = (
+export const convertGeometryFromCocoAnnotationToLabel = (
   cocoSegmentation: number[][],
   bbox: number[], // [x, y, width, height]
   imageHeight: number
@@ -65,9 +65,9 @@ export const convertCocoSegmentationToLabel = (
         ? [
             [
               [bbox[0], bbox[1] + bbox[3]],
-              [bbox[0] + bbox[2], bbox[1] + bbox[3]],
-              [bbox[0] + bbox[2], bbox[1]],
               [bbox[0], bbox[1]],
+              [bbox[0] + bbox[2], bbox[1]],
+              [bbox[0] + bbox[2], bbox[1] + bbox[3]],
               [bbox[0], bbox[1] + bbox[3]],
             ],
           ]

--- a/typescript/common-resolvers/src/utils/__tests__/validate-upload-mime-types.ts
+++ b/typescript/common-resolvers/src/utils/__tests__/validate-upload-mime-types.ts
@@ -1,0 +1,45 @@
+import {
+  ValidMimeTypeCategory,
+  isFilePathOfValidMimeTypeCategory,
+} from "../validate-upload-mime-types";
+
+describe("isFilePathOfValidMimeTypeCategory", () => {
+  test("Should spot a valid image filename", () => {
+    expect(
+      isFilePathOfValidMimeTypeCategory(
+        "image.jpg",
+        ValidMimeTypeCategory.image
+      )
+    ).toBeTruthy();
+  });
+  test("Should spot a valid image path", () => {
+    expect(
+      isFilePathOfValidMimeTypeCategory(
+        "some/random/path/to/my/image.jpg",
+        ValidMimeTypeCategory.image
+      )
+    ).toBeTruthy();
+  });
+  test("Should spot a valid image filename with an uncommon uppercase extension", () => {
+    expect(
+      isFilePathOfValidMimeTypeCategory(
+        "image.JPEG",
+        ValidMimeTypeCategory.image
+      )
+    ).toBeTruthy();
+  });
+  test("Should spot an invalid (unsupported) image filename", () => {
+    expect(
+      isFilePathOfValidMimeTypeCategory(
+        "image.tiff",
+        ValidMimeTypeCategory.image
+      )
+    ).toBeFalsy();
+  });
+  test("Should spot a valid upload filename", () => {
+    expect(isFilePathOfValidMimeTypeCategory("archive.zip")).toBeTruthy();
+  });
+  test("Should spot an invalid upload filename", () => {
+    expect(isFilePathOfValidMimeTypeCategory("archive.tar.gz")).toBeFalsy();
+  });
+});

--- a/typescript/common-resolvers/src/utils/validate-upload-mime-types.ts
+++ b/typescript/common-resolvers/src/utils/validate-upload-mime-types.ts
@@ -42,13 +42,8 @@ export function getValidMimeTypeCategoriesList(
       );
 }
 
-export function getValidMimeTypeCategoriesListString(
-  categories: ValidMimeTypeCategory[] | undefined = undefined
-): string {
-  return getValidMimeTypeCategoriesList(categories).join(", ");
-}
-
-export const validMimeTypesFlatString = getValidMimeTypeCategoriesListString();
+export const validMimeTypesFlatString =
+  getValidMimeTypeCategoriesList().join(", ");
 
 export function isFilePathOfValidMimeTypeCategory(
   filePath: string,

--- a/typescript/common-resolvers/src/utils/validate-upload-mime-types.ts
+++ b/typescript/common-resolvers/src/utils/validate-upload-mime-types.ts
@@ -52,12 +52,14 @@ export const validMimeTypesFlatString = getValidMimeTypeCategoriesListString();
 
 export function isFilePathOfValidMimeTypeCategory(
   filePath: string,
-  category: ValidMimeTypeCategory
+  category: ValidMimeTypeCategory | undefined = undefined
 ): boolean {
   const filePathMimeType = mime.lookup(filePath);
   return filePathMimeType === false
     ? false
-    : validMimeTypes[category].includes(filePathMimeType as string);
+    : (category ? validMimeTypes[category] : validMimeTypesFlat).includes(
+        filePathMimeType as string
+      );
 }
 
 // TODO implement in a way that works both for front and back

--- a/typescript/common-resolvers/src/utils/validate-upload-mime-types.ts
+++ b/typescript/common-resolvers/src/utils/validate-upload-mime-types.ts
@@ -1,0 +1,85 @@
+import mime from "mime-types";
+import JSZip from "jszip";
+
+export enum ValidMimeTypeCategory {
+  image = "image",
+  archive = "archive",
+  json = "json",
+}
+
+export const validMimeTypes: Record<ValidMimeTypeCategory, string[]> = {
+  image: ["image/jpeg", "image/png", "image/bmp"],
+  archive: ["application/zip"],
+  json: ["application/json"],
+};
+
+export const validMimeTypesFlat: string[] = Object.values(
+  validMimeTypes
+).reduce<string[]>(
+  (mimeTypesFlat, mimeTypeList) =>
+    mimeTypeList.reduce<string[]>((mimeTypesFlatSub, mimeTypeString) => {
+      mimeTypesFlatSub.push(mimeTypeString);
+      return mimeTypesFlatSub;
+    }, mimeTypesFlat),
+  [] as string[]
+);
+
+export function getValidMimeTypeCategoriesList(
+  categories: ValidMimeTypeCategory[] | undefined = undefined
+): string[] {
+  return categories === undefined
+    ? validMimeTypesFlat
+    : Object.values(categories).reduce<string[]>(
+        (mimeTypesFlat, mimeTypeCategory) =>
+          validMimeTypes[mimeTypeCategory].reduce<string[]>(
+            (mimeTypesFlatSub, mimeTypeString) => {
+              mimeTypesFlatSub.push(mimeTypeString);
+              return mimeTypesFlatSub;
+            },
+            mimeTypesFlat
+          ),
+        [] as string[]
+      );
+}
+
+export function getValidMimeTypeCategoriesListString(
+  categories: ValidMimeTypeCategory[] | undefined = undefined
+): string {
+  return getValidMimeTypeCategoriesList(categories).join(", ");
+}
+
+export const validMimeTypesFlatString = getValidMimeTypeCategoriesListString();
+
+export function isFilePathOfValidMimeTypeCategory(
+  filePath: string,
+  category: ValidMimeTypeCategory
+): boolean {
+  const filePathMimeType = mime.lookup(filePath);
+  return filePathMimeType === false
+    ? false
+    : validMimeTypes[category].includes(filePathMimeType as string);
+}
+
+// TODO implement in a way that works both for front and back
+/*
+export async function isStreamOfValidMimeTypeCategory(
+  stream: NodeJS.ReadableStream,
+  category: ValidMimeTypeCategory
+): Promise<boolean> {
+  return true;
+  const { mime: streamMimeType } = await fileTypeFromStream(stream as Readable);
+  return streamMimeType
+    ? validMimeTypes[category].includes(streamMimeType)
+    : false;
+}
+*/
+
+// TODO also check binary mime type markers
+export async function isJSZipObjectOfValidMimeTypeCategory(
+  filePath: string,
+  jszipObject: JSZip.JSZipObject,
+  category: ValidMimeTypeCategory
+): Promise<boolean> {
+  return isFilePathOfValidMimeTypeCategory(filePath, category);
+  /* && (await isStreamOfValidMimeTypeCategory(jszipObject.nodeStream(), category)) */
+}

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/dropzone.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/dropzone.tsx
@@ -3,6 +3,7 @@ import { chakra, Stack, useColorModeValue as mode } from "@chakra-ui/react";
 import { RiUploadCloud2Line } from "react-icons/ri";
 import { useDropzone, FileWithPath, FileRejection } from "react-dropzone";
 import { isEmpty } from "lodash/fp";
+import { validMimeTypesFlatString } from "@labelflow/common-resolvers/src/utils/validate-upload-mime-types";
 import { DroppedFile } from "../types";
 
 const UploadIcon = chakra(RiUploadCloud2Line);
@@ -23,8 +24,7 @@ export const Dropzone = ({
     getRootProps: () => object;
     getInputProps: () => object;
   } = useDropzone({
-    accept:
-      "image/jpeg, image/png, image/bmp, application/zip, application/json",
+    accept: validMimeTypesFlatString,
   });
 
   useEffect(() => {


### PR DESCRIPTION
# Feature

- Images in imported zip files for COCO do not need to be in the "images" subfolder anymore, but can be anyway in the archive structure.
- IDs of entities in COCO are not expected anymore to following a specific pattern (starting from 1, without gaps, ...)
- Annotations from COCO that have no segmentation will be considered and imported as box labels, according to their bbox data.
- Put a common source of authority for files mime types support for both front-end components and back-end importers in `typescript/common-resolvers/src/utils/validate-upload-mime-types.ts`

## Caveats

Images are just looked into the zip files from their extension, the best practice would be to also look into their binary data for proper markers of their mime type, but we need to do it in a way that is both supported by nodejs and the service worker.

## Resolved issues

Closes #569 

