### PR TITLE
Remove cross-projects relative imports

### DIFF
--- a/typescript/common-resolvers/src/types.ts
+++ b/typescript/common-resolvers/src/types.ts
@@ -22,9 +22,9 @@ import type {
   WorkspaceCreateInput,
   WorkspaceWhereInput,
   WorkspaceWhereUniqueInput,
+  WorkspacePlan,
   WorkspaceType,
 } from "@labelflow/graphql-types";
-import { WorkspacePlan } from "@prisma/client";
 
 type NoUndefinedField<T> = { [P in keyof T]: NonNullable<T[P]> };
 

--- a/typescript/db/src/repository/upload-s3.ts
+++ b/typescript/db/src/repository/upload-s3.ts
@@ -2,8 +2,8 @@ import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import "isomorphic-fetch";
 import memoizeOne from "memoize-one";
-import { Repository } from "../../../common-resolvers/src";
-import { UploadTargetHttp } from "../../../graphql-types/src/graphql-types.generated";
+import { Repository } from "@labelflow/common-resolvers";
+import { UploadTargetHttp } from "@labelflow/graphql-types";
 
 const bucket = "labelflow";
 const region = process.env?.LABELFLOW_AWS_REGION!;

--- a/typescript/db/src/repository/upload-supabase.ts
+++ b/typescript/db/src/repository/upload-supabase.ts
@@ -2,8 +2,8 @@ import { createClient } from "@supabase/supabase-js";
 import "isomorphic-fetch";
 import memoizeOne from "memoize-one";
 
-import { Repository } from "../../../common-resolvers/src";
-import { UploadTargetHttp } from "../../../graphql-types/src/graphql-types.generated";
+import { Repository } from "@labelflow/common-resolvers";
+import { UploadTargetHttp } from "@labelflow/graphql-types";
 
 const getClient = memoizeOne(() =>
   createClient(


### PR DESCRIPTION
# Feature

## Work performed

They were some cross-projects relative imports. I've changed them to `@labelflow/*`

## Results

No more imports using relative path between the projects of this monorepo

## Problems encountered

No

## Caveats

None

## Resolved issues

Needed by #615 

## Newly raised issues

None
