### PR TITLE
Define a unique key prop in class-selection-popover list

### DIFF
--- a/typescript/web/src/components/class-selection-popover/class-selection-popover.tsx
+++ b/typescript/web/src/components/class-selection-popover/class-selection-popover.tsx
@@ -269,6 +269,7 @@ export const ClassSelectionPopover = ({
                   const item = filteredLabelClasses[index];
                   return (
                     <Box
+                      key={item.name}
                       style={{
                         position: "absolute",
                         top: 0,
@@ -292,7 +293,6 @@ export const ClassSelectionPopover = ({
                           "type" in item && item.type === "CreateClassItem"
                         }
                         index={index}
-                        key={item.name}
                       />
                     </Box>
                   );


### PR DESCRIPTION
# Feature

## Work performed

Fixed warning:

```text
 Warning: Each child in a list should have a unique "key" prop.
      
      Check the render method of `ClassSelectionPopover`. See https://reactjs.org/link/warning-keys for more information.
          at Styled(div) (/Users/bbenoist/src/labelflow/workspaces/node_modules/@emotion/react/dist/emotion-element-deca0de5.cjs.dev.js:35:23)
          at ClassSelectionPopover (/Users/bbenoist/src/labelflow/workspaces/typescript/web/src/components/class-selection-popover/class-selection-popover.tsx:74:3)
          at div
          at /Users/bbenoist/src/labelflow/workspaces/typescript/web/src/components/labeling-tool/openlayers-map/edit-label-class.tsx:81:6
          at ApolloProvider (/Users/bbenoist/src/labelflow/workspaces/node_modules/@apollo/client/react/context/ApolloProvider.js:5:21)
          at wrapper (/Users/bbenoist/src/labelflow/workspaces/typescript/web/src/components/labeling-tool/openlayers-map/__tests__/edit-label-class.tsx:85:17)
```

## Results

1 warning removed

## Problems encountered

No

## Caveats

None

## Resolved issues

None

## Newly raised issues

None
