### PR TITLE
Don't skip any Jest test

### DIFF
--- a/cypress/integration/invitation-manager.online.ts
+++ b/cypress/integration/invitation-manager.online.ts
@@ -178,8 +178,7 @@ describe("Invitation Manager (online)", () => {
     cy.location("pathname").should("eq", "/local/datasets");
   });
 
-  // flacky in the CI
-  it.skip("should open the sign in modal if the user isn't logged in", () => {
+  it("should open the sign in modal if the user isn't logged in", () => {
     // log in as the default user
     cy.task("performLogin").then((token) => {
       cy.setCookie("next-auth.session-token", token as string);

--- a/cypress/integration/invitation-manager.online.ts
+++ b/cypress/integration/invitation-manager.online.ts
@@ -197,12 +197,9 @@ describe("Invitation Manager (online)", () => {
 
     // try closing the sign in modals
     cy.contains("Sign in to LabelFlow").should("be.visible");
-    // need to click twice to loose the focus?
-    cy.get(`button[aria-label="Close"]`).click();
     cy.get(`button[aria-label="Close"]`).click();
 
     cy.contains("You need to sign in to continue").should("be.visible");
-    cy.get("button").contains("Sign In").click();
     cy.contains("Sign in to LabelFlow").should("be.visible");
     cy.get(`button[aria-label="Close"]`).click();
 

--- a/typescript/db/src/resolvers/__tests__/dataset.ts
+++ b/typescript/db/src/resolvers/__tests__/dataset.ts
@@ -273,7 +273,7 @@ describe("Access control for dataset", () => {
       })
     ).rejects.toThrow(`User not authorized to access dataset`);
   });
-  it.only("allows to get all information from nested resolvers", async () => {
+  it("allows to get all information from nested resolvers", async () => {
     await createWorkspace({ name: "My workspace" });
     const createdDataset = await createDataset("My dataset", "my-workspace");
 

--- a/typescript/web/src/components/labeling-tool/openlayers-map/__tests__/edit-label-class.tsx
+++ b/typescript/web/src/components/labeling-tool/openlayers-map/__tests__/edit-label-class.tsx
@@ -152,7 +152,7 @@ it("should create a class", async () => {
   });
 });
 
-it.only("should change a class", async () => {
+it("should change a class", async () => {
   renderEditLabelClass();
 
   await waitFor(() =>


### PR DESCRIPTION
# Feature

## Work performed

Some tests were skipped.

## Results

```text
Test Suites: 69 passed, 69 total
Tests:       504 passed, 504 total
Snapshots:   6 passed, 6 total
Time:        129.025 s, estimated 173 s
```

## Problems encountered

I still don't really understand why these tests were skipped.

* It wasn't clear why they were some `it.only`
* I'm sure that we can resolve most the flacky issues.

## Caveats

Flacky tests will be back

## Resolved issues

No more skipped tests

## Newly raised issues

- [ ] Fix most of the flacky tests
