### PR TITLE
Disable non-deterministic react-openlayers-fiber stories

### DIFF
--- a/typescript/react-openlayers-fiber/src/__stories__/accessible.stories.tsx
+++ b/typescript/react-openlayers-fiber/src/__stories__/accessible.stories.tsx
@@ -32,3 +32,7 @@ export const AccessibleMap = () => {
     </div>
   );
 };
+
+AccessibleMap.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/typescript/react-openlayers-fiber/src/__stories__/basic.stories.tsx
+++ b/typescript/react-openlayers-fiber/src/__stories__/basic.stories.tsx
@@ -2,6 +2,13 @@ import React from "react";
 import { useInterval } from "react-use";
 import { Map } from "../map";
 
+export default {
+  title: "react-openlayers-fiber/Other Examples",
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+};
+
 /**
  * In this story we prefix the props with initial for the view, so it should be initially at these values
  * and allow free movement after, never reseting the view position

--- a/typescript/react-openlayers-fiber/src/__stories__/draw-and-modify-features.stories.tsx
+++ b/typescript/react-openlayers-fiber/src/__stories__/draw-and-modify-features.stories.tsx
@@ -72,3 +72,7 @@ export const DrawAndModifyFeatures = () => {
     </>
   );
 };
+
+DrawAndModifyFeatures.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/typescript/react-openlayers-fiber/src/__stories__/draw-shapes.stories.tsx
+++ b/typescript/react-openlayers-fiber/src/__stories__/draw-shapes.stories.tsx
@@ -96,3 +96,7 @@ export const DrawShapes = () => {
     </>
   );
 };
+
+DrawShapes.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/typescript/react-openlayers-fiber/src/__stories__/popup.stories.tsx
+++ b/typescript/react-openlayers-fiber/src/__stories__/popup.stories.tsx
@@ -82,3 +82,7 @@ export const Popup = () => {
     </div>
   );
 };
+
+Popup.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/typescript/react-openlayers-fiber/src/__stories__/turf.stories.tsx
+++ b/typescript/react-openlayers-fiber/src/__stories__/turf.stories.tsx
@@ -67,3 +67,7 @@ export const Turf = () => {
     </Map>
   );
 };
+
+Turf.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/typescript/react-openlayers-fiber/src/__stories__/wms-tiled.stories.tsx
+++ b/typescript/react-openlayers-fiber/src/__stories__/wms-tiled.stories.tsx
@@ -20,3 +20,7 @@ export const TiledWMS = () => {
     </Map>
   );
 };
+
+TiledWMS.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/typescript/react-openlayers-fiber/src/__stories__/xyz.stories.tsx
+++ b/typescript/react-openlayers-fiber/src/__stories__/xyz.stories.tsx
@@ -12,3 +12,7 @@ export const XYZ = () => {
     </Map>
   );
 };
+
+XYZ.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/typescript/web/src/components/welcome-manager/__stories__/welcome-modal.tsx
+++ b/typescript/web/src/components/welcome-manager/__stories__/welcome-modal.tsx
@@ -87,8 +87,21 @@ Loading.parameters = {
   },
 };
 
+/**
+ * The Welcome Modal displays a countdown.
+ * This is non-deterministic, so we can't do snapshot testing here.
+ * The next story is the same welcome modal, but without a countdown.
+ * So, it's deterministic and can be snapshot tested.
+ */
 export const Welcome = () => {
   return <WelcomeManager />;
+};
+Welcome.parameters = {
+  chromatic: { disableSnapshot: true },
+};
+
+export const WelcomeWithoutCountDown = () => {
+  return <WelcomeManager autoStartCountDown={false} />;
 };
 
 Welcome.parameters = {

--- a/typescript/web/src/components/welcome-manager/steps/welcome.tsx
+++ b/typescript/web/src/components/welcome-manager/steps/welcome.tsx
@@ -26,19 +26,26 @@ const SpeedIcon = chakra(RiSpeedMiniFill);
 type Props = {
   onClickNext: () => void;
   onClickSkip?: () => void;
+  autoStartCountDown?: boolean;
 };
 
 const delayMilliSeconds = 10 * 1000;
 
-export const Welcome = ({ onClickSkip, onClickNext }: Props) => {
+export const Welcome = ({
+  onClickSkip,
+  onClickNext,
+  autoStartCountDown = true,
+}: Props) => {
   const [isCountDownStarted, setIsCountDownStarted] = useState(false);
   const [timeLeft, { start }] = useCountDown(delayMilliSeconds, 1000 / 30);
   const startLabelingButtonRef = useRef<HTMLButtonElement>(null);
   // Start the timer during the first render
   useEffect(() => {
-    setIsCountDownStarted(true);
-    start();
-    startLabelingButtonRef.current?.focus();
+    if (autoStartCountDown) {
+      setIsCountDownStarted(true);
+      start();
+      startLabelingButtonRef.current?.focus();
+    }
   }, []);
 
   useEffect(() => {

--- a/typescript/web/src/components/welcome-manager/welcome-modal.tsx
+++ b/typescript/web/src/components/welcome-manager/welcome-modal.tsx
@@ -152,11 +152,13 @@ export const WelcomeModal = ({
   initialBrowserWarning = false,
   initialIsLoadingWorkerAndDemo = false,
   initialBrowserError = undefined,
+  autoStartCountDown = true,
 }: {
   initialIsServiceWorkerActive?: boolean;
   initialBrowserWarning?: boolean;
   initialIsLoadingWorkerAndDemo?: boolean;
   initialBrowserError?: Error;
+  autoStartCountDown?: boolean;
 }) => {
   const router = useRouter();
 
@@ -355,7 +357,11 @@ export const WelcomeModal = ({
         // Nominal welcome modal on first vist after loading
         if (shouldShowWelcomeModal) {
           return (
-            <Welcome onClickSkip={handleSkip} onClickNext={handleGetStarted} />
+            <Welcome
+              onClickSkip={handleSkip}
+              onClickNext={handleGetStarted}
+              autoStartCountDown={autoStartCountDown}
+            />
           );
         }
 

--- a/typescript/web/src/components/workspace-name-input/workspace-name-message.tsx
+++ b/typescript/web/src/components/workspace-name-input/workspace-name-message.tsx
@@ -1,4 +1,5 @@
 import { isEmpty } from "lodash/fp";
+import { useMockableLocation } from "../../utils/mockable-location";
 import { OptionalText } from "../optional-text";
 import { useWorkspaceNameInput } from "./workspace-name-input.context";
 
@@ -17,10 +18,10 @@ const useUrlMessage = (
   isEditing: boolean | undefined
 ): string | undefined => {
   const { slug } = useWorkspaceNameInput();
-  const hideUrl =
-    !isEmpty(error) || isEmpty(slug) || isEmpty(globalThis.location);
+  const { origin } = useMockableLocation();
+  const hideUrl = !isEmpty(error) || isEmpty(slug) || isEmpty(origin);
   if (hideUrl) return undefined;
-  const workspaceUrl = `${globalThis.location.origin}/${slug}`;
+  const workspaceUrl = `${origin}/${slug}`;
   return isEditing
     ? `Workspace URL: ${workspaceUrl}`
     : `URL will be: ${workspaceUrl}`;

--- a/typescript/web/src/components/workspace-switcher/create-workspace-modal/__stories__/create-workspace-modal.stories.tsx
+++ b/typescript/web/src/components/workspace-switcher/create-workspace-modal/__stories__/create-workspace-modal.stories.tsx
@@ -2,6 +2,7 @@ import { MockedProvider as ApolloProvider } from "@apollo/client/testing";
 import { Story } from "@storybook/react";
 import { CreateWorkspaceModal } from "..";
 import { chakraDecorator } from "../../../../utils/chakra-decorator";
+import { MockableLocationProvider } from "../../../../utils/mockable-location";
 import { queryParamsDecorator } from "../../../../utils/query-params-decorator";
 import {
   WORKSPACE_EXISTS_MOCK_ALREADY_TAKEN_NAME,
@@ -21,7 +22,9 @@ const Template = () => (
     ]}
   >
     <div>
-      <CreateWorkspaceModal isOpen onClose={console.log} />
+      <MockableLocationProvider location="http://localhost">
+        <CreateWorkspaceModal isOpen onClose={console.log} />
+      </MockableLocationProvider>
     </div>
   </ApolloProvider>
 );

--- a/typescript/web/src/components/workspace-switcher/create-workspace-modal/__tests__/create-workspace-modal.test.tsx
+++ b/typescript/web/src/components/workspace-switcher/create-workspace-modal/__tests__/create-workspace-modal.test.tsx
@@ -1,19 +1,18 @@
 import { ApolloProvider } from "@apollo/client";
 import { FORBIDDEN_WORKSPACE_SLUGS } from "@labelflow/common-resolvers";
-import { render, RenderResult, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { isNil } from "lodash/fp";
-import { PropsWithChildren, ReactElement, useState } from "react";
+import { PropsWithChildren, useState } from "react";
 import { client } from "../../../../connectors/apollo-client/schema-client";
+import { MockableLocationProvider } from "../../../../utils/mockable-location";
 import { CreateWorkspaceModal } from "../create-workspace-modal";
 
-export const ApolloWrapper = ({ children }: PropsWithChildren<{}>) => (
-  <ApolloProvider client={client}>{children}</ApolloProvider>
+export const Wrapper = ({ children }: PropsWithChildren<{}>) => (
+  <MockableLocationProvider>
+    <ApolloProvider client={client}>{children}</ApolloProvider>
+  </MockableLocationProvider>
 );
-
-export const renderWithApollo = (ui: ReactElement): RenderResult => {
-  return render(ui, { wrapper: ApolloWrapper });
-};
 
 const INITIAL_QUERY_PARAMS = { "workspace-name": undefined };
 
@@ -83,7 +82,9 @@ const runTest = async ({
   expected,
 }: TestCase) => {
   initQueryParams(testCaseQueryParams);
-  renderWithApollo(<CreateWorkspaceModal isOpen onClose={handleClose} />);
+  render(<CreateWorkspaceModal isOpen onClose={handleClose} />, {
+    wrapper: Wrapper,
+  });
   validateInput(
     workspaceName,
     workspaceName ?? testCaseQueryParams?.["workspace-name"]

--- a/typescript/web/src/pages/_app.tsx
+++ b/typescript/web/src/pages/_app.tsx
@@ -19,6 +19,7 @@ import {
 } from "../connectors/apollo-client/client";
 import { QueryParamProvider } from "../utils/query-params-provider";
 import ErrorPage from "./_error";
+import { MockableLocationProvider } from "../utils/mockable-location";
 
 interface InitialProps {
   cookie: string;
@@ -100,14 +101,16 @@ const App = (props: AppProps & InitialProps) => {
           <ApolloProvider client={client}>
             <QueryParamProvider>
               <ChakraProvider theme={theme} resetCSS>
-                <Head>
-                  {/* Set proper initial appearance of content for mobile */}
-                  <meta
-                    name="viewport"
-                    content="width=device-width, initial-scale=1.0"
-                  />
-                </Head>
-                <Component {...pageProps} />
+                <MockableLocationProvider>
+                  <Head>
+                    {/* Set proper initial appearance of content for mobile */}
+                    <meta
+                      name="viewport"
+                      content="width=device-width, initial-scale=1.0"
+                    />
+                  </Head>
+                  <Component {...pageProps} />
+                </MockableLocationProvider>
               </ChakraProvider>
             </QueryParamProvider>
           </ApolloProvider>

--- a/typescript/web/src/utils/mockable-location.tsx
+++ b/typescript/web/src/utils/mockable-location.tsx
@@ -1,0 +1,54 @@
+import { createContext, PropsWithChildren, useContext } from "react";
+
+export class MockedLocation extends URL implements Location {
+  ancestorOrigins = {} as DOMStringList; // Unused in our code
+
+  /* eslint-disable class-methods-use-this */
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  assign(url: string | URL): void {
+    throw new Error("Method not implemented.");
+  }
+
+  reload(): void {
+    throw new Error("Method not implemented.");
+  }
+
+  replace(url: string | URL): void {
+    throw new Error("Method not implemented.");
+  }
+  /* eslint-enable class-methods-use-this */
+  /* eslint-enable @typescript-eslint/no-unused-vars */
+}
+
+export type MockableLocation = Location | MockedLocation;
+
+export type MockableLocationState = { location: MockableLocation };
+
+const MockableLocationContext = createContext({} as MockableLocationState);
+
+export type MockableLocationProviderProps = PropsWithChildren<{
+  location?: MockableLocation | string;
+}>;
+
+const getMockableLocation = (
+  location: MockableLocationProviderProps["location"]
+): MockableLocation => {
+  return typeof location === "string"
+    ? new MockedLocation(location)
+    : location ?? globalThis.location;
+};
+
+export const MockableLocationProvider = ({
+  location,
+  children,
+}: MockableLocationProviderProps) => (
+  <MockableLocationContext.Provider
+    value={{ location: getMockableLocation(location) }}
+  >
+    {children}
+  </MockableLocationContext.Provider>
+);
+
+export const useMockableLocation = (): Location => {
+  return useContext(MockableLocationContext).location;
+};


### PR DESCRIPTION
## Work performed

- Simply disabled snapshot testing for the non-deterministic stories of react-openlayers-fiber
- Disabled the snapshot test for the WelcomeModal with the countdown
- Added a new story of the WelcomeModal without a countdown. Added snapshot tests for this story
- Make WorkspaceCreationModal and WorkspaceNameInput components accept an `origin` prop only specified on stories.

## Results

To be accepted only once: 
https://www.chromatic.com/build?appId=60a646559841590039471afc&number=2644

## Problems encountered

I am not sure to understand why, but it seems that the UI validation step thought I added new stories:
https://www.chromatic.com/build?appId=60a646559841590039471afc&number=2644


