### PR TITLE
Add and optimize DB schema indexes

### DIFF
--- a/typescript/db/migrations/20220105162621_optimized_indexes/migration.sql
+++ b/typescript/db/migrations/20220105162621_optimized_indexes/migration.sql
@@ -1,0 +1,44 @@
+-- DropIndex
+DROP INDEX "LabelClass.name_datasetId_index";
+
+-- CreateIndex
+CREATE INDEX "Account.userId_index" ON "Account"("userId");
+
+-- CreateIndex
+CREATE INDEX "Dataset.workspaceSlug_createdAt_index" ON "Dataset"("workspaceSlug", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Dataset.createdAt_index" ON "Dataset"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "Image.datasetId_createdAt_index" ON "Image"("datasetId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Label.labelClassId_index" ON "Label"("labelClassId");
+
+-- CreateIndex
+CREATE INDEX "Label.imageId_createdAt_index" ON "Label"("imageId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "LabelClass.datasetId_createdAt_index" ON "LabelClass"("datasetId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "LabelClass.datasetId_name_index" ON "LabelClass"("datasetId", "name");
+
+-- CreateIndex
+CREATE INDEX "Membership.workspaceSlug_createdAt_index" ON "Membership"("workspaceSlug", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Session.userId_index" ON "Session"("userId");
+
+-- CreateIndex
+CREATE INDEX "User.createdAt_index" ON "User"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "Workspace.slug_deletedAt_createdAt_index" ON "Workspace"("slug", "deletedAt", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Workspace.createdAt_index" ON "Workspace"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "Workspace.name_index" ON "Workspace"("name");

--- a/typescript/db/schema.prisma
+++ b/typescript/db/schema.prisma
@@ -36,6 +36,8 @@ model Image {
   thumbnail200Url String?
   thumbnail500Url String?
   metadata        Json?
+
+  @@index([datasetId, createdAt])
 }
 
 model Label {
@@ -53,6 +55,9 @@ model Label {
   image          Image       @relation(fields: [imageId], references: [id], onDelete: Cascade)
   labelClass     LabelClass? @relation(fields: [labelClassId], references: [id])
   smartToolInput Json?
+
+  @@index([labelClassId])
+  @@index([imageId, createdAt])
 }
 
 model LabelClass {
@@ -65,7 +70,9 @@ model LabelClass {
   datasetId String   @db.Uuid
   dataset   Dataset  @relation(fields: [datasetId], references: [id], onDelete: Cascade)
   labels    Label[]
-  @@index([name, datasetId])
+
+  @@index([datasetId, createdAt])
+  @@index([datasetId, name])
 }
 
 model Dataset {
@@ -81,6 +88,8 @@ model Dataset {
 
   @@unique(fields: [workspaceSlug, slug], name: "slugs")
   @@unique(fields: [workspaceSlug, name], name: "workspaceSlugAndDatasetName")
+  @@index([workspaceSlug, createdAt])
+  @@index([createdAt])
 }
 
 model Workspace {
@@ -97,6 +106,10 @@ model Workspace {
   stripeCustomerId String?
   datasets         Dataset[]
   memberships      Membership[]
+
+  @@index([slug, deletedAt, createdAt])
+  @@index([createdAt])
+  @@index([name])
 }
 
 model Membership {
@@ -113,6 +126,7 @@ model Membership {
 
   @@unique([workspaceSlug, userId])
   @@unique([workspaceSlug, invitationEmailSentTo])
+  @@index([workspaceSlug, createdAt])
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -139,6 +153,7 @@ model Account {
   user               User     @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
 
   @@unique([provider, providerAccountId], name: "provider_providerAccountId")
+  @@index([userId])
 }
 
 model Session {
@@ -149,6 +164,8 @@ model Session {
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
   user         User     @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+
+  @@index([userId])
 }
 
 model User {
@@ -162,6 +179,8 @@ model User {
   accounts      Account[]
   sessions      Session[]
   memberships   Membership[]
+
+  @@index([createdAt])
 }
 
 model VerificationToken {


### PR DESCRIPTION
## Work performed

WIP

## Results

So far, I've just added a few indexes for:
 - The most obvious filters use-cases
 - createdAt order by

## Problems encountered

It would be nice to investigate a bit the efficiency of those indexes before continuing. Here is a non-exhausting list of subjects to investigate:
- Do we need created at for order by
- Do we need to add compound indexes for order by and filters (i.e. `createdAt, datasetId`) And in which order should we write it.
- Check existing order of compound indexes

## Caveats

<!--- Any particular attention point with what you did? -->

## Resolved issues

<!--- List references to issues that this PR resolves -->

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
