### PR TITLE
Display a more meaningful error message in the app when createWorkspace fails

### DIFF
--- a/typescript/common-resolvers/src/utils/validate-workspace-name.ts
+++ b/typescript/common-resolvers/src/utils/validate-workspace-name.ts
@@ -41,6 +41,7 @@ export enum WorkspaceNameErrorType {
   invalidNameCharacters = "invalidNameCharacters",
   emptySlug = "emptySlug",
   forbiddenSlug = "forbiddenSlug",
+  workspaceExists = "workspaceExists",
 }
 
 export const validateWorkspaceName = (
@@ -70,6 +71,7 @@ export const INVALID_WORKSPACE_NAME_MESSAGES: Record<
   invalidNameCharacters: "Name contains invalid characters",
   emptySlug: "Slug is empty",
   forbiddenSlug: "This name is reserved",
+  workspaceExists: `A workspace with this name already exists`,
 };
 
 export const validWorkspaceName = (

--- a/typescript/db/package.json
+++ b/typescript/db/package.json
@@ -33,6 +33,7 @@
     "@graphql-tools/schema": "7.1.5",
     "@labelflow/common-resolvers": "workspace:typescript/common-resolvers",
     "@labelflow/graphql-types": "workspace:typescript/graphql-types",
+    "@labelflow/utils": "workspace:typescript/utils",
     "@prisma/client": "2.30.3",
     "@supabase/supabase-js": "1.21.0",
     "apollo-server": "3.5.0",

--- a/typescript/react-openlayers-fiber/package.json
+++ b/typescript/react-openlayers-fiber/package.json
@@ -15,7 +15,7 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "lodash": "^4.17.21",
+    "lodash": "4.17.21",
     "react-reconciler": "0.25.1",
     "scheduler": "0.20.1"
   },

--- a/typescript/utils/package.json
+++ b/typescript/utils/package.json
@@ -4,5 +4,8 @@
   "version": "0.0.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
-  "sideEffects": false
+  "sideEffects": false,
+  "dependencies": {
+    "lodash": "4.17.21"
+  }
 }

--- a/typescript/utils/src/__tests__/override-error.test.ts
+++ b/typescript/utils/src/__tests__/override-error.test.ts
@@ -1,0 +1,68 @@
+import { isEmpty } from "lodash/fp";
+import { ErrorOverride, withErrorOverrides, withErrorOverridesAsync } from "..";
+
+type TestCase = [string | undefined, string | undefined];
+
+const SPECIFIC_ERROR_MESSAGE = "Specific error to override";
+const CUSTOM_ERROR_MESSAGE = "Custom error message";
+
+const overrideSpecificError: ErrorOverride = (error) => {
+  if (error instanceof Error && error.message === SPECIFIC_ERROR_MESSAGE) {
+    throw new Error(CUSTOM_ERROR_MESSAGE);
+  }
+};
+
+const ERROR_OVERRIDES: ErrorOverride[] = [overrideSpecificError];
+
+const throwErrorIfDefined = (error: string | undefined): void => {
+  if (isEmpty(error)) return;
+  throw new Error(error);
+};
+
+const fn = (error: string | undefined) =>
+  jest.fn(() => throwErrorIfDefined(error));
+
+const fnAsync = (error: string | undefined) =>
+  jest.fn(async () => throwErrorIfDefined(error));
+
+const runTest = ([error, expected]: TestCase) => {
+  const throwError = fn(error);
+  const actual = withErrorOverrides(throwError, ERROR_OVERRIDES);
+  if (!isEmpty(expected)) {
+    expect(actual).toThrow(expected);
+  }
+};
+
+const runAsyncTest = async ([error, expected]: TestCase) => {
+  const throwError = fnAsync(error);
+  const actual = withErrorOverridesAsync(throwError, ERROR_OVERRIDES);
+  if (!isEmpty(expected)) {
+    await expect(actual).rejects.toThrow(expected);
+  }
+};
+
+const TEST_CASES: Record<string, TestCase> = {
+  "throws a custom error if the override is matching": [
+    SPECIFIC_ERROR_MESSAGE,
+    CUSTOM_ERROR_MESSAGE,
+  ],
+  "throws the initial error if the override is not matching": [
+    "Another message",
+    "Another message",
+  ],
+  "does not throw any error if the specified function didn't fail": [
+    undefined,
+    undefined,
+  ],
+};
+
+const TEST_CASES_ENTRIES = Object.entries(TEST_CASES).flatMap<
+  [string, () => Promise<void>]
+>(([description, testCase]) => [
+  [`${description} (sync)`, async () => runTest(testCase)],
+  [`${description} (async)`, async () => await runAsyncTest(testCase)],
+]);
+
+describe("override-error", () => {
+  it.concurrent.each(TEST_CASES_ENTRIES)("%s", async (_, exec) => await exec());
+});

--- a/typescript/utils/src/index.ts
+++ b/typescript/utils/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./class-color-generator";
+export * from "./override-error";

--- a/typescript/utils/src/override-error.ts
+++ b/typescript/utils/src/override-error.ts
@@ -1,0 +1,51 @@
+export type ErrorOverride = (error: unknown) => void;
+
+export const overrideError = (error: unknown, prettifiers: ErrorOverride[]) => {
+  prettifiers.forEach((prettify) => prettify(error));
+  throw error;
+};
+
+export const callWithErrorOverrides = <TParameters extends unknown[], TReturn>(
+  fn: (...params: TParameters) => TReturn,
+  params: TParameters,
+  prettifiers: ErrorOverride[]
+): TReturn => {
+  try {
+    return fn(...params);
+  } catch (error) {
+    overrideError(error, prettifiers);
+    throw error;
+  }
+};
+
+export const withErrorOverrides = <TParameters extends unknown[], TResult>(
+  fn: (...params: TParameters) => TResult,
+  prettifiers: ErrorOverride[]
+): ((...params: TParameters) => TResult) => {
+  return (...args: TParameters) =>
+    callWithErrorOverrides<TParameters, TResult>(fn, args, prettifiers);
+};
+
+export const callWithErrorOverridesAsync = async <
+  TParameters extends unknown[],
+  TReturn
+>(
+  fn: (...params: TParameters) => Promise<TReturn>,
+  params: TParameters,
+  prettifiers: ErrorOverride[]
+): Promise<TReturn> => {
+  try {
+    return await fn(...params);
+  } catch (error) {
+    overrideError(error, prettifiers);
+    throw error;
+  }
+};
+
+export const withErrorOverridesAsync = <TParameters extends unknown[], TResult>(
+  fn: (...params: TParameters) => Promise<TResult>,
+  prettifiers: ErrorOverride[]
+): ((...params: TParameters) => Promise<TResult>) => {
+  return (...args: TParameters) =>
+    callWithErrorOverridesAsync<TParameters, TResult>(fn, args, prettifiers);
+};

--- a/typescript/web/src/components/settings/workspace/profile.tsx
+++ b/typescript/web/src/components/settings/workspace/profile.tsx
@@ -17,7 +17,7 @@ import { useCallback } from "react";
 import { RiGroupFill } from "react-icons/ri";
 import { Card, FieldGroup, HeadingGroup } from "..";
 import { randomBackgroundGradient } from "../../../utils/random-background-gradient";
-import { useApolloErrorToast } from "../../toast";
+import { useApolloError } from "../../error-handlers";
 import {
   useWorkspaceNameInput,
   WorkspaceNameInput,
@@ -50,7 +50,7 @@ const useUpdateWorkspace = (): [() => void, string | undefined] => {
   const router = useRouter();
   const workspace = useWorkspaceSettings();
   const { name } = useWorkspaceNameInput();
-  const onError = useApolloErrorToast();
+  const onError = useApolloError();
   const [updateWorkspace, { error }] = useMutation<
     Pick<Mutation, "updateWorkspace">
   >(updateWorkspaceMutation, {

--- a/typescript/web/src/components/toast.ts
+++ b/typescript/web/src/components/toast.ts
@@ -1,6 +1,7 @@
 import { ApolloError } from "@apollo/client";
 import { AlertStatus, useToast as useChakraToast } from "@chakra-ui/react";
 import { useCallback } from "react";
+import { getApolloErrorMessage } from "../utils/get-apollo-error-message";
 
 /**
  * Returns a toast reusable across the application
@@ -39,7 +40,10 @@ export const useApolloErrorToast = () => {
   const toast = useErrorToast();
   return useCallback(
     (error: ApolloError) => {
-      toast("Error while contacting the GraphQL server", error.message);
+      toast(
+        "Error while contacting the GraphQL server",
+        getApolloErrorMessage(error)
+      );
     },
     [toast]
   );

--- a/typescript/web/src/components/workspace-name-input/workspace-name-input.fixtures.tsx
+++ b/typescript/web/src/components/workspace-name-input/workspace-name-input.fixtures.tsx
@@ -2,7 +2,10 @@ import {
   MockedProvider as ApolloProvider,
   MockedResponse as ApolloResponse,
 } from "@apollo/client/testing";
-import { FORBIDDEN_WORKSPACE_SLUGS } from "@labelflow/common-resolvers";
+import {
+  FORBIDDEN_WORKSPACE_SLUGS,
+  INVALID_WORKSPACE_NAME_MESSAGES,
+} from "@labelflow/common-resolvers";
 import { Mutation, Query } from "@labelflow/graphql-types";
 import { isEmpty, isNil } from "lodash/fp";
 import { useEffect } from "react";
@@ -84,18 +87,18 @@ export const TEST_CASES: Record<string, TestCase> = {
   ],
   "warns if the name is a reserved name": [
     { name: FORBIDDEN_WORKSPACE_SLUGS[0] },
-    `This name is reserved`,
+    INVALID_WORKSPACE_NAME_MESSAGES.forbiddenSlug,
   ],
   "warns if the name contains invalid characters": [
     { name: "hello!" },
-    "Name contains invalid characters",
+    INVALID_WORKSPACE_NAME_MESSAGES.invalidNameCharacters,
   ],
   "warns if the name is already taken": [
     {
       name: "Already taken name",
       graphqlMocks: [WORKSPACE_EXISTS_MOCK_ALREADY_TAKEN_NAME],
     },
-    "A workspace with the slug already-taken-name already exists",
+    INVALID_WORKSPACE_NAME_MESSAGES.workspaceExists,
   ],
   "displays the error if given one": [
     { customError: "this is an error" },

--- a/typescript/web/src/utils/get-apollo-error-message.tsx
+++ b/typescript/web/src/utils/get-apollo-error-message.tsx
@@ -1,0 +1,30 @@
+import { ApolloError } from "@apollo/client";
+import { isEmpty, isNil } from "lodash/fp";
+
+const getApolloNetworkErrorMessage = (
+  error: ApolloError["networkError"]
+): string | undefined => {
+  if (isNil(error)) return undefined;
+  if ("result" in error) {
+    // ServerError.result type is is Record<string, any>
+    const result = error.result as
+      | { errors?: { message?: string }[] }
+      | undefined;
+    if (isNil(result) || isNil(result.errors)) return undefined;
+    const firstMessage = result.errors.find(({ message }) => !isEmpty(message));
+    if (!isNil(firstMessage)) return firstMessage.message;
+  }
+  return error.message;
+};
+
+/**
+ * Tries to find the more meaningful error as possible from an ApolloError
+ * @param error - The error to analyze
+ */
+export const getApolloErrorMessage = (error: ApolloError): string => {
+  const { graphQLErrors, networkError } = error;
+  if (!isEmpty(graphQLErrors)) return graphQLErrors[0].message;
+  const networkMessage = getApolloNetworkErrorMessage(networkError);
+  if (!isNil(networkMessage)) return networkMessage;
+  return error.message;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6649,6 +6649,7 @@ __metadata:
     "@graphql-tools/schema": 7.1.5
     "@labelflow/common-resolvers": "workspace:typescript/common-resolvers"
     "@labelflow/graphql-types": "workspace:typescript/graphql-types"
+    "@labelflow/utils": "workspace:typescript/utils"
     "@prisma/client": 2.30.3
     "@supabase/supabase-js": 1.21.0
     "@types/node": 16.4.1
@@ -6699,7 +6700,7 @@ __metadata:
     "@types/react-dom": 17.0.0
     "@types/react-reconciler": ^0.26.1
     "@types/storybook__react": 4.0.1
-    lodash: ^4.17.21
+    lodash: 4.17.21
     ol: 6.6.1
     ol-mapbox-style: 6.4.1
     proj4: 2.6.3
@@ -6746,6 +6747,8 @@ __metadata:
 "@labelflow/utils@workspace:typescript/utils":
   version: 0.0.0-use.local
   resolution: "@labelflow/utils@workspace:typescript/utils"
+  dependencies:
+    lodash: 4.17.21
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Work performed

<!--- Concisely describe what was done, this will appear in the public changelog -->
I've added `getApolloErrorMessage` which tries to find the more meaningful error as possible so that it can be displayed to the user.

## Results

<!--- Does this pull-request fully implement the new feature? If not why? Create and link new issues. -->
![image](https://user-images.githubusercontent.com/2091902/147761864-e91a6f0c-e872-47dd-95ba-49b47b56c5e4.png)

## Problems encountered

<!--- Explain problems that were encountered when implementing this pull-request -->
* Prisma errors are not fully typed
* Apollo errors are not fully typed

## Caveats

<!--- Any particular attention point with what you did? -->
We might miss additional errors.

## Resolved issues

<!--- List references to issues that this PR resolves -->
Closing #710 
Also related with #712 

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
No