### PR TITLE
Fix bug creating duplicate label classes from modal

### DIFF
--- a/typescript/web/src/components/dataset-classes/upsert-class-modal/modal-body.tsx
+++ b/typescript/web/src/components/dataset-classes/upsert-class-modal/modal-body.tsx
@@ -10,7 +10,12 @@ import { ModalContext } from "./modal-context";
 export const ModalBody = () => {
   return (
     <ModalContext.Consumer>
-      {({ classNameInputValue, handleInputValueChange, errorMessage }) => {
+      {({
+        classNameInputValue,
+        handleInputValueChange,
+        errorMessage,
+        isClassCreationPending,
+      }) => {
         return (
           <ChakraModalBody pt="0" pb="6" pr="20" pl="20">
             <FormControl isInvalid={errorMessage !== ""} isRequired>
@@ -22,6 +27,7 @@ export const ModalBody = () => {
                 onChange={handleInputValueChange}
                 aria-label="Class name input"
                 autoFocus
+                disabled={isClassCreationPending}
               />
               <FormErrorMessage>{errorMessage}</FormErrorMessage>
             </FormControl>

--- a/typescript/web/src/components/dataset-classes/upsert-class-modal/modal-body.tsx
+++ b/typescript/web/src/components/dataset-classes/upsert-class-modal/modal-body.tsx
@@ -1,39 +1,31 @@
 import {
-  ModalBody as ChakraModalBody,
   FormControl,
   FormErrorMessage,
   FormLabel,
   Input,
+  ModalBody as ChakraModalBody,
 } from "@chakra-ui/react";
+import { useContext } from "react";
 import { ModalContext } from "./modal-context";
 
 export const ModalBody = () => {
+  const { classNameInputValue, handleInputValueChange, errorMessage, loading } =
+    useContext(ModalContext);
   return (
-    <ModalContext.Consumer>
-      {({
-        classNameInputValue,
-        handleInputValueChange,
-        errorMessage,
-        isClassCreationPending,
-      }) => {
-        return (
-          <ChakraModalBody pt="0" pb="6" pr="20" pl="20">
-            <FormControl isInvalid={errorMessage !== ""} isRequired>
-              <FormLabel>Name</FormLabel>
-              <Input
-                value={classNameInputValue}
-                placeholder="Class name"
-                size="md"
-                onChange={handleInputValueChange}
-                aria-label="Class name input"
-                autoFocus
-                disabled={isClassCreationPending}
-              />
-              <FormErrorMessage>{errorMessage}</FormErrorMessage>
-            </FormControl>
-          </ChakraModalBody>
-        );
-      }}
-    </ModalContext.Consumer>
+    <ChakraModalBody pt="0" pb="6" pr="20" pl="20">
+      <FormControl isInvalid={errorMessage !== ""} isRequired>
+        <FormLabel>Name</FormLabel>
+        <Input
+          value={classNameInputValue}
+          placeholder="Class name"
+          size="md"
+          onChange={handleInputValueChange}
+          aria-label="Class name input"
+          autoFocus
+          disabled={loading}
+        />
+        <FormErrorMessage>{errorMessage}</FormErrorMessage>
+      </FormControl>
+    </ChakraModalBody>
   );
 };

--- a/typescript/web/src/components/dataset-classes/upsert-class-modal/modal-context.tsx
+++ b/typescript/web/src/components/dataset-classes/upsert-class-modal/modal-context.tsx
@@ -6,6 +6,7 @@ export interface UpsertClassModalState {
   classNameInputValue: string;
   errorMessage: string;
   handleInputValueChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  isClassCreationPending: boolean;
 }
 
 export const ModalContext = React.createContext<UpsertClassModalState>({
@@ -14,4 +15,5 @@ export const ModalContext = React.createContext<UpsertClassModalState>({
   classNameInputValue: "",
   errorMessage: "",
   handleInputValueChange: () => {},
+  isClassCreationPending: false,
 });

--- a/typescript/web/src/components/dataset-classes/upsert-class-modal/modal-context.tsx
+++ b/typescript/web/src/components/dataset-classes/upsert-class-modal/modal-context.tsx
@@ -6,7 +6,7 @@ export interface UpsertClassModalState {
   classNameInputValue: string;
   errorMessage: string;
   handleInputValueChange: (e: ChangeEvent<HTMLInputElement>) => void;
-  isClassCreationPending: boolean;
+  loading: boolean;
 }
 
 export const ModalContext = React.createContext<UpsertClassModalState>({
@@ -15,5 +15,5 @@ export const ModalContext = React.createContext<UpsertClassModalState>({
   classNameInputValue: "",
   errorMessage: "",
   handleInputValueChange: () => {},
-  isClassCreationPending: false,
+  loading: false,
 });

--- a/typescript/web/src/components/dataset-classes/upsert-class-modal/modal-footer.tsx
+++ b/typescript/web/src/components/dataset-classes/upsert-class-modal/modal-footer.tsx
@@ -3,20 +3,13 @@ import { ModalContext } from "./modal-context";
 
 export const ModalFooter = () => (
   <ModalContext.Consumer>
-    {({
-      errorMessage,
-      classNameInputValue,
-      classId,
-      isClassCreationPending,
-    }) => (
+    {({ errorMessage, classNameInputValue, classId, loading }) => (
       <ChakraModalFooter>
         <Button
           type="submit"
           colorScheme="brand"
           disabled={
-            classNameInputValue === "" ||
-            errorMessage !== "" ||
-            isClassCreationPending
+            classNameInputValue === "" || errorMessage !== "" || loading
           }
           aria-label={classId ? "Update" : "Create"}
         >

--- a/typescript/web/src/components/dataset-classes/upsert-class-modal/modal-footer.tsx
+++ b/typescript/web/src/components/dataset-classes/upsert-class-modal/modal-footer.tsx
@@ -3,12 +3,21 @@ import { ModalContext } from "./modal-context";
 
 export const ModalFooter = () => (
   <ModalContext.Consumer>
-    {({ errorMessage, classNameInputValue, classId }) => (
+    {({
+      errorMessage,
+      classNameInputValue,
+      classId,
+      isClassCreationPending,
+    }) => (
       <ChakraModalFooter>
         <Button
           type="submit"
           colorScheme="brand"
-          disabled={classNameInputValue === "" || errorMessage !== ""}
+          disabled={
+            classNameInputValue === "" ||
+            errorMessage !== "" ||
+            isClassCreationPending
+          }
           aria-label={classId ? "Update" : "Create"}
         >
           {classId ? "Update" : "Create"}

--- a/typescript/web/src/components/dataset-classes/upsert-class-modal/update-label-class-name.mutation.ts
+++ b/typescript/web/src/components/dataset-classes/upsert-class-modal/update-label-class-name.mutation.ts
@@ -1,4 +1,4 @@
-import { gql, useApolloClient } from "@apollo/client";
+import { gql, MutationResult, useMutation } from "@apollo/client";
 import { useCallback } from "react";
 
 export const UPDATE_LABEL_CLASS_NAME_MUTATION = gql`
@@ -15,10 +15,12 @@ export const useUpdateLabelClass = (
   classId: string | undefined,
   className: string,
   classColor: string | undefined
-) => {
-  const client = useApolloClient();
-  return useCallback(async () => {
-    await client.mutate({
+): [() => Promise<void>, MutationResult<{}>] => {
+  const [updateLabelClass, result] = useMutation(
+    UPDATE_LABEL_CLASS_NAME_MUTATION
+  );
+  const onUpdate = useCallback(async () => {
+    await updateLabelClass({
       mutation: UPDATE_LABEL_CLASS_NAME_MUTATION,
       variables: { id: classId, name: className },
       optimisticResponse: {
@@ -30,5 +32,6 @@ export const useUpdateLabelClass = (
         },
       },
     });
-  }, [client, classId, className, classColor]);
+  }, [updateLabelClass, classId, className, classColor]);
+  return [onUpdate, result];
 };

--- a/typescript/web/src/components/dataset-classes/upsert-class-modal/upsert-class-modal.tsx
+++ b/typescript/web/src/components/dataset-classes/upsert-class-modal/upsert-class-modal.tsx
@@ -24,7 +24,8 @@ const useCreateClass = (
   className: string,
   classColor: string | undefined,
   onClose: () => void,
-  setErrorMessage: (message: string) => void
+  setErrorMessage: (message: string) => void,
+  setPendingStatus: (isPending: boolean) => void
 ) => {
   const workspaceSlug = useRouter()?.query?.workspaceSlug as string | undefined;
   const updateLabelClass = useUpdateLabelClass(classId, className, classColor);
@@ -39,6 +40,7 @@ const useCreateClass = (
       event.preventDefault();
       if (isEmpty(className)) return;
       try {
+        setPendingStatus(true);
         if (!isNil(classId)) {
           await updateLabelClass();
         } else {
@@ -52,6 +54,8 @@ const useCreateClass = (
         } else {
           throw error;
         }
+      } finally {
+        setPendingStatus(false);
       }
     },
     [
@@ -61,6 +65,7 @@ const useCreateClass = (
       onClose,
       setErrorMessage,
       updateLabelClass,
+      setPendingStatus,
     ]
   );
 };
@@ -112,6 +117,8 @@ const useModalState = ({ isOpen, onClose }: UpsertClassModalProps) => {
   const { editClass, datasetId, datasetSlug } = useDatasetClasses();
   const [classNameInputValue, setClassNameInputValue] = useState<string>("");
   const [errorMessage, setErrorMessage] = useState<string>("");
+  const [isClassCreationPending, setIsClassCreationPending] =
+    useState<boolean>(false);
   const handleInputValueChange = (event: ChangeEvent<HTMLInputElement>) => {
     setClassNameInputValue(event.target.value);
   };
@@ -125,7 +132,8 @@ const useModalState = ({ isOpen, onClose }: UpsertClassModalProps) => {
     className,
     editClass?.color ?? undefined,
     onClose,
-    setErrorMessage
+    setErrorMessage,
+    setIsClassCreationPending
   );
   useModalObserver(isOpen, setClassNameInputValue, setErrorMessage, editClass);
   return {
@@ -134,6 +142,7 @@ const useModalState = ({ isOpen, onClose }: UpsertClassModalProps) => {
     classNameInputValue,
     errorMessage,
     handleInputValueChange,
+    isClassCreationPending,
   };
 };
 


### PR DESCRIPTION
## Work performed

- Prevented class creation modal form from being submitted again while a query to create a new class is still ongoing.

## Results

- It shouldn't be possible anymore to create multiple classes with the same name at once

## Resolved issues

Solves #705 