### PR TITLE
Update error message when different signin method is used

### DIFF
--- a/typescript/web/src/components/auth-manager/signin-modal/__stories__/signin-modal.tsx
+++ b/typescript/web/src/components/auth-manager/signin-modal/__stories__/signin-modal.tsx
@@ -26,6 +26,7 @@ const useStory = (linkSent?: string): SignInModalState => {
   };
 };
 
+<<<<<<< HEAD
 export const Opened = () => (
   <SignInModalContext.Provider value={useStory()}>
     <SignInModal />
@@ -37,3 +38,28 @@ export const LinkSent = () => (
     <SignInModal />
   </SignInModalContext.Provider>
 );
+=======
+export const LinkSent = () => {
+  return (
+    <SigninModal
+      isOpen
+      linkSent="example@company.com"
+      setIsOpen={() => {}}
+      setError={() => {}}
+      setLinkSent={() => {}}
+    />
+  );
+};
+
+export const ErrorSigninMethod = () => {
+  return (
+    <SigninModal
+      isOpen
+      error="OAuthAccountNotLinked"
+      setIsOpen={() => {}}
+      setError={() => {}}
+      setLinkSent={() => {}}
+    />
+  );
+};
+>>>>>>> fe2bfe18 (Fix style + add story)

--- a/typescript/web/src/components/auth-manager/signin-modal/__stories__/signin-modal.tsx
+++ b/typescript/web/src/components/auth-manager/signin-modal/__stories__/signin-modal.tsx
@@ -9,8 +9,7 @@ export default {
   title: "web/Signin/Modal",
   decorators: [chakraDecorator, apolloDecorator],
 };
-
-const useStory = (linkSent?: string): SignInModalState => {
+const useStory = (linkSent?: string, error?: string): SignInModalState => {
   const [email, setEmail] = useState("");
   return {
     isOpen: true,
@@ -20,13 +19,12 @@ const useStory = (linkSent?: string): SignInModalState => {
     setSendingLink: () => {},
     signIn: async () => {},
     validEmail: validateEmail(email),
-    error: undefined,
+    error,
     linkSent,
     sendingLink: undefined,
   };
 };
 
-<<<<<<< HEAD
 export const Opened = () => (
   <SignInModalContext.Provider value={useStory()}>
     <SignInModal />
@@ -38,28 +36,9 @@ export const LinkSent = () => (
     <SignInModal />
   </SignInModalContext.Provider>
 );
-=======
-export const LinkSent = () => {
-  return (
-    <SigninModal
-      isOpen
-      linkSent="example@company.com"
-      setIsOpen={() => {}}
-      setError={() => {}}
-      setLinkSent={() => {}}
-    />
-  );
-};
 
-export const ErrorSigninMethod = () => {
-  return (
-    <SigninModal
-      isOpen
-      error="OAuthAccountNotLinked"
-      setIsOpen={() => {}}
-      setError={() => {}}
-      setLinkSent={() => {}}
-    />
-  );
-};
->>>>>>> fe2bfe18 (Fix style + add story)
+export const ErrorSigninMethod = () => (
+  <SignInModalContext.Provider value={useStory("", "OAuthAccountNotLinked")}>
+    <SignInModal />
+  </SignInModalContext.Provider>
+);

--- a/typescript/web/src/components/auth-manager/signin-modal/email-signin.tsx
+++ b/typescript/web/src/components/auth-manager/signin-modal/email-signin.tsx
@@ -51,10 +51,14 @@ const EmailSubmitButton = () => {
 };
 
 const EmailFormControls = () => {
-  const { validEmail } = useSignInModal();
+  const { validEmail, email } = useSignInModal();
   return (
     <>
-      <FormControl id="email" isRequired isInvalid={!validEmail}>
+      <FormControl
+        id="email"
+        isRequired
+        isInvalid={!isEmpty(email) && !validEmail}
+      >
         <EmailInput />
       </FormControl>
       <EmailSubmitButton />

--- a/typescript/web/src/components/auth-manager/signin-modal/email-signin.tsx
+++ b/typescript/web/src/components/auth-manager/signin-modal/email-signin.tsx
@@ -54,7 +54,7 @@ const EmailFormControls = () => {
   const { validEmail } = useSignInModal();
   return (
     <>
-      <FormControl id="email" isRequired isInvalid={validEmail}>
+      <FormControl id="email" isRequired isInvalid={!validEmail}>
         <EmailInput />
       </FormControl>
       <EmailSubmitButton />

--- a/typescript/web/src/components/auth-manager/signin-modal/signin-error.tsx
+++ b/typescript/web/src/components/auth-manager/signin-modal/signin-error.tsx
@@ -10,8 +10,8 @@ const AUTHENTICATION_ERRORS = {
   OAuthCreateAccount: "Try signing in with a different account.",
   EmailCreateAccount: "Try signing in with a different account.",
   Callback: "Try signing in with a different account.",
-  OAuthAccountNotLinked:
-    "To confirm your identity, sign in with the same account you used originally.",
+  OAuthAccountNotLinked: `We could not sign you in. If you have already signed
+  in with this email address, try again using the same method you originally used.`,
   EmailSignin: "Check your email inbox.",
   CredentialsSignin:
     "Sign in failed. Check the details you provided are correct.",

--- a/typescript/web/src/components/auth-manager/signin-modal/signin-modal.context.tsx
+++ b/typescript/web/src/components/auth-manager/signin-modal/signin-modal.context.tsx
@@ -147,6 +147,7 @@ const useSendingLink = (
   response: SignInResponse | undefined
 ): [
   Pick<SignInState, "sendingLink" | "setSendingLink" | "linkSent">,
+  () => Promise<void>,
   () => Promise<void>
 ] => {
   const { close } = useSignInModal();
@@ -167,6 +168,7 @@ const useSendingLink = (
     [response]
   );
   const clearSendingLink = useClearQueryParam(setSendingLink);
+  const clearLinkSent = useClearQueryParam(setLinkSent);
   return [
     {
       sendingLink,
@@ -174,16 +176,20 @@ const useSendingLink = (
       linkSent: linkSent || undefined,
     },
     clearSendingLink,
+    clearLinkSent,
   ];
 };
 
 const useSignIn = (): [SignInState, () => Promise<void>] => {
   const [signInState, response, clearError] = useSignInWithError();
-  const [sendingLinkState, clearSendingLink] = useSendingLink(response);
+  const [sendingLinkState, clearSendingLink, clearLinkSent] =
+    useSendingLink(response);
+
   const clearQueryParams = useCallback(async () => {
     await clearError();
     await clearSendingLink();
-  }, [clearError, clearSendingLink]);
+    await clearLinkSent();
+  }, [clearError, clearSendingLink, clearLinkSent]);
   return [{ ...signInState, ...sendingLinkState }, clearQueryParams];
 };
 


### PR DESCRIPTION
## Work performed

- Update the error message when a user try to sign in with a different method than the first he choose
- Add a trim function for the error message as Google seems to add a `#` when redirecting from its login page

## Problems encountered

It seems that when you first use the Google login, when it redirects you to labelflow page, it adds a `#` at the end of URL which cause the error message to be incorrectly displayed (it showed the `default` one as it didn't match any other)

## Resolved issues

Closes #708 
