### PR TITLE
Trim white spaces around email addresses

### DIFF
--- a/typescript/web/src/components/members/new-member-modal.tsx
+++ b/typescript/web/src/components/members/new-member-modal.tsx
@@ -132,7 +132,7 @@ user2@example.com
                     : ""
                 } ${
                   hasInvalidEmails
-                    ? "\nAt lease one email format is invalid. Write one email address per line."
+                    ? "\nAt lease one email format is invalid. Emails should be separated by , ; or spaces."
                     : ""
                 }`}
               </Text>

--- a/typescript/web/src/components/members/new-member-modal.tsx
+++ b/typescript/web/src/components/members/new-member-modal.tsx
@@ -61,7 +61,6 @@ export const NewMemberModal = ({
   };
   const emails = value
     .split(/[,;\s]/)
-    .map((email) => email.trim())
     .filter((email) => email !== "");
   const hasInvalidEmails = emails.some((email) => !validateEmail(email));
 

--- a/typescript/web/src/components/members/new-member-modal.tsx
+++ b/typescript/web/src/components/members/new-member-modal.tsx
@@ -1,34 +1,38 @@
-import { useState, ChangeEvent } from "react";
 import {
-  Flex,
   Alert,
-  AlertIcon,
   AlertDescription,
-  VStack,
+  AlertIcon,
+  Button,
+  Flex,
+  Heading,
+  Link,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
   Text,
   Textarea,
-  Modal,
-  ModalOverlay,
-  ModalContent,
-  ModalCloseButton,
-  ModalFooter,
-  Button,
-  Heading,
-  ModalHeader,
-  ModalBody,
   useColorModeValue as mode,
-  Link,
   useToast,
+  VStack,
 } from "@chakra-ui/react";
+import { InvitationResult, MembershipRole } from "@labelflow/graphql-types";
+import { isEmpty } from "lodash/fp";
 import { useRouter } from "next/router";
-import { MembershipRole, InvitationResult } from "@labelflow/graphql-types";
-
+import { ChangeEvent, useState } from "react";
+import { validateEmail } from "../../utils/validate-email";
 import { RoleSelection } from "./role-selection";
 import { InviteMember } from "./types";
-import { validateEmail } from "../../utils/validate-email";
 
 const maxNumberOfEmails = 20;
 type EmailStatuses = Record<InvitationResult, string[]>;
+
+const parseEmails = (text: string): string[] => {
+  return text.split(/[,;\s]/).filter((email) => !isEmpty(email));
+};
 
 const summarizeEmailList = (emailList: string[]): string => {
   if (emailList.length === 1) {
@@ -59,9 +63,7 @@ export const NewMemberModal = ({
     const inputValue = e.target.value;
     setValue(inputValue);
   };
-  const emails = value
-    .split(/[,;\s]/)
-    .filter((email) => email !== "");
+  const emails = parseEmails(value);
   const hasInvalidEmails = emails.some((email) => !validateEmail(email));
 
   return (

--- a/typescript/web/src/components/members/new-member-modal.tsx
+++ b/typescript/web/src/components/members/new-member-modal.tsx
@@ -131,7 +131,7 @@ user2@example.com
                     : ""
                 } ${
                   hasInvalidEmails
-                    ? "\nAt lease one email format is invalid. Emails should be separated by , ; or spaces."
+                    ? "\nAt least one email address is invalid. Addresses can be separated by new lines, spaces, commas or semicolons."
                     : ""
                 }`}
               </Text>

--- a/typescript/web/src/components/members/new-member-modal.tsx
+++ b/typescript/web/src/components/members/new-member-modal.tsx
@@ -60,9 +60,9 @@ export const NewMemberModal = ({
     setValue(inputValue);
   };
   const emails = value
-    .split("\n")
-    .filter((email) => email !== "")
-    .map((email) => email.trim());
+    .split(/[,;\s]/)
+    .map((email) => email.trim())
+    .filter((email) => email !== "");
   const hasInvalidEmails = emails.some((email) => !validateEmail(email));
 
   return (

--- a/typescript/web/src/components/members/new-member-modal.tsx
+++ b/typescript/web/src/components/members/new-member-modal.tsx
@@ -59,7 +59,10 @@ export const NewMemberModal = ({
     const inputValue = e.target.value;
     setValue(inputValue);
   };
-  const emails = value.split("\n").filter((email) => email !== "");
+  const emails = value
+    .split("\n")
+    .filter((email) => email !== "")
+    .map((email) => email.trim());
   const hasInvalidEmails = emails.some((email) => !validateEmail(email));
 
   return (

--- a/typescript/web/src/utils/validate-email.tsx
+++ b/typescript/web/src/utils/validate-email.tsx
@@ -1,5 +1,5 @@
 export const validateEmail = (email: string): boolean => {
   const re =
     /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-  return re.test(String(email).toLowerCase());
+  return re.test(String(email).toLowerCase().trim());
 };

--- a/typescript/web/src/utils/validate-email.tsx
+++ b/typescript/web/src/utils/validate-email.tsx
@@ -1,5 +1,5 @@
 export const validateEmail = (email: string): boolean => {
   const re =
     /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-  return re.test(String(email).toLowerCase().trim());
+  return re.test(String(email).toLowerCase());
 };


### PR DESCRIPTION
## Work performed

<!--- Concisely describe what was done, this will appear in the public changelog -->
trim white spaces around email addresses

## Results

<!--- Does this pull-request fully implement the new feature? If not why? Create and link new issues. -->
An email address can now have leading or trailing white spaces around it and still be valid as it is trimmed prior to verification.

## Problems encountered

<!--- Explain problems that were encountered when implementing this pull-request -->

## Caveats

<!--- Any particular attention point with what you did? -->

## Resolved issues

<!--- List references to issues that this PR resolves -->

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
