### PR TITLE
Increase testing-library/react default timeout to 30s

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@storybook/manager-webpack5": "next",
     "@storybook/react": "6.3.12",
     "@testing-library/jest-dom": "5.14.1",
+    "@testing-library/react": "11.2.6",
     "@typescript-eslint/eslint-plugin": "4.23.0",
     "@typescript-eslint/parser": "4.23.0",
     "auto-changelog": "2.3.0",

--- a/setup-tests.ts
+++ b/setup-tests.ts
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom";
 import "fake-indexeddb/auto";
+import { configure } from "@testing-library/react";
 import fetchMock from "jest-fetch-mock";
 import CacheStorage from "service-worker-mock/models/CacheStorage";
 import Request from "service-worker-mock/models/Request";
@@ -10,6 +11,12 @@ Object.assign(global, {
   Request,
   Response,
 });
+
+// FIXME Default timeout is often exceeded on our CI
+const TESTING_LIBRARY_TIMEOUT = 30000;
+const JEST_TIMEOUT = TESTING_LIBRARY_TIMEOUT * 2;
+jest.setTimeout(JEST_TIMEOUT);
+configure({ asyncUtilTimeout: TESTING_LIBRARY_TIMEOUT });
 
 fetchMock.enableMocks();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -23875,6 +23875,7 @@ fsevents@^1.2.7:
     "@storybook/manager-webpack5": next
     "@storybook/react": 6.3.12
     "@testing-library/jest-dom": 5.14.1
+    "@testing-library/react": 11.2.6
     "@typescript-eslint/eslint-plugin": 4.23.0
     "@typescript-eslint/parser": 4.23.0
     auto-changelog: 2.3.0


### PR DESCRIPTION
## Work performed

<!--- Concisely describe what was done, this will appear in the public changelog -->
I've increased the default timeout used with testing-library `waitFor` function.

## Results

<!--- Does this pull-request fully implement the new feature? If not why? Create and link new issues. -->
CI tests should not fail randomly anymore 🚀 

## Problems encountered

<!--- Explain problems that were encountered when implementing this pull-request -->
Our tests are too slow to execute, even when only testing a single file.

## Caveats

<!--- Any particular attention point with what you did? -->
We'll have to wait more time when tests timeouts are legit 🐌

## Resolved issues

<!--- List references to issues that this PR resolves -->
Might fix #730 🙏 

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
**TODO** Create issue `Make our unit tests run faster`