### PR TITLE
Fix bad aggregates count for workspace > datasets queries

### DIFF
--- a/typescript/common-resolvers/src/dataset.ts
+++ b/typescript/common-resolvers/src/dataset.ts
@@ -19,7 +19,7 @@ import {
 import { getWorkspaceIdOfDataset } from "./image/get-workspace-id-of-dataset";
 import { importAndProcessImage } from "./image/import-and-process-image";
 import { Context, DbDataset, Repository } from "./types";
-import { getSlug } from "./utils";
+import { getSlug, addTypename, addTypenames } from "./utils";
 
 const getLabelClassesByDatasetId = async (
   datasetId: string,
@@ -40,7 +40,7 @@ const getDataset = async (
       `Couldn't find dataset corresponding to ${JSON.stringify(where)}`
     );
   }
-  return { ...datasetFromRepository, __typename: "Dataset" };
+  return addTypename(datasetFromRepository, "Dataset");
 };
 
 const searchDataset = async (
@@ -54,7 +54,7 @@ const searchDataset = async (
       user
     );
     return datasetFromRepository != null
-      ? { ...datasetFromRepository, __typename: "Dataset" }
+      ? addTypename(datasetFromRepository, "Dataset")
       : undefined;
   } catch (error) {
     if (
@@ -122,10 +122,7 @@ const datasets = async (
     args.first
   );
 
-  return queryResult.map((datasetWithoutTypename) => ({
-    ...datasetWithoutTypename,
-    __typename: "Dataset",
-  }));
+  return addTypenames(queryResult, "Dataset");
 };
 
 // Mutations
@@ -177,7 +174,7 @@ const createDemoDataset = async (
     user
   );
   if (!isNil(existing)) {
-    return { ...existing, __typename: "Dataset" };
+    return addTypename(existing, "Dataset");
   }
   await repository.dataset.add({ ...tutorialDatasets[0] }, user);
 

--- a/typescript/common-resolvers/src/label.ts
+++ b/typescript/common-resolvers/src/label.ts
@@ -16,6 +16,7 @@ import { DbLabel, Context, Repository } from "./types";
 
 import { throwIfResolvesToNil } from "./utils/throw-if-resolves-to-nil";
 import { getBoundedGeometryFromImage } from "./utils/get-bounded-geometry-from-image";
+import { addTypename } from "./utils";
 
 const LABEL_CLASS_ID_PROPERTY_NAMES: Record<
   "Dataset" | "LabelClass",
@@ -189,14 +190,14 @@ const labelsAggregatesOfDataset = (parent: Dataset) => {
   if (!parent) {
     throw new Error("No parent Dataset");
   }
-  return { ...parent, __typename: "Dataset" };
+  return addTypename(parent, "Dataset");
 };
 
 const labelsAggregatesOfLabelClass = (parent: LabelClass) => {
   if (!parent) {
     throw new Error("No parent LabelClass");
   }
-  return { ...parent, __typename: "LabelClass" };
+  return addTypename(parent, "LabelClass");
 };
 
 const totalCount = async (

--- a/typescript/common-resolvers/src/utils/add-typename.ts
+++ b/typescript/common-resolvers/src/utils/add-typename.ts
@@ -1,0 +1,13 @@
+export const addTypename = <TRecord extends object, TTypename extends string>(
+  data: TRecord,
+  typename: TTypename
+): TRecord & { __typename: TTypename } => {
+  return { ...data, __typename: typename };
+};
+
+export const addTypenames = <TRecord extends object, TTypename extends string>(
+  data: TRecord[],
+  typename: TTypename
+): (TRecord & { __typename: TTypename })[] => {
+  return data.map((item) => addTypename<TRecord, TTypename>(item, typename));
+};

--- a/typescript/common-resolvers/src/utils/index.ts
+++ b/typescript/common-resolvers/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from "./get-slug";
 export * from "./validate-workspace-name";
+export * from "./add-typename";

--- a/typescript/db/src/resolvers/workspace.ts
+++ b/typescript/db/src/resolvers/workspace.ts
@@ -153,10 +153,15 @@ const memberships = async (parent: DbWorkspaceWithType) => {
 
 const datasets = async (parent: DbWorkspaceWithType) => {
   const db = await getPrismaClient();
-  return await db.dataset.findMany({
+  const queryResult = await db.dataset.findMany({
     where: { workspaceSlug: parent.slug },
     orderBy: { createdAt: Prisma.SortOrder.asc },
   });
+
+  return queryResult.map((datasetWithoutTypename) => ({
+    ...datasetWithoutTypename,
+    __typename: "Dataset",
+  }));
 };
 
 const stripeCustomerPortalUrl = async (

--- a/typescript/db/src/resolvers/workspace.ts
+++ b/typescript/db/src/resolvers/workspace.ts
@@ -3,6 +3,8 @@ import {
   DbWorkspace,
   DbWorkspaceWithType,
   Repository,
+  addTypename,
+  addTypenames,
 } from "@labelflow/common-resolvers";
 import {
   Membership,
@@ -21,12 +23,6 @@ import { AuthorizationError } from "../repository/authorization-error";
 import { castObjectNullsToUndefined } from "../repository/utils";
 import { stripe } from "../utils";
 
-const addTypename = <TData extends DbWorkspaceWithType | DbWorkspace>(
-  data: TData
-): TData & { __typename: "Workspace" } => {
-  return { ...data, __typename: "Workspace" };
-};
-
 function foundWorkspace<TData extends DbWorkspaceWithType | DbWorkspace>(
   data: TData | null | undefined,
   input: WorkspaceWhereUniqueInput
@@ -44,7 +40,7 @@ const getWorkspace = async (
 ): Promise<DbWorkspaceWithType & { __typename: "Workspace" }> => {
   const data = await repository.workspace.get(where, user);
   foundWorkspace(data, where);
-  return addTypename(data);
+  return addTypename(data, "Workspace");
 };
 
 const workspace = async (
@@ -136,7 +132,7 @@ const deleteWorkspace = async (
   const db = await getPrismaClient();
   const data = await db.workspace.findUnique({ where: { id } });
   foundWorkspace(data, args.where);
-  return addTypename(data);
+  return addTypename(data, "Workspace");
 };
 
 const memberships = async (parent: DbWorkspaceWithType) => {
@@ -157,11 +153,7 @@ const datasets = async (parent: DbWorkspaceWithType) => {
     where: { workspaceSlug: parent.slug },
     orderBy: { createdAt: Prisma.SortOrder.asc },
   });
-
-  return queryResult.map((datasetWithoutTypename) => ({
-    ...datasetWithoutTypename,
-    __typename: "Dataset",
-  }));
+  return addTypenames(queryResult, "Dataset");
 };
 
 const stripeCustomerPortalUrl = async (

--- a/typescript/web/src/connectors/resolvers/workspace.ts
+++ b/typescript/web/src/connectors/resolvers/workspace.ts
@@ -2,7 +2,11 @@ import {
   QueryWorkspaceArgs,
   QueryWorkspacesArgs,
 } from "@labelflow/graphql-types";
-import { Context, DbWorkspaceWithType } from "@labelflow/common-resolvers";
+import {
+  addTypenames,
+  Context,
+  DbWorkspaceWithType,
+} from "@labelflow/common-resolvers";
 import { notImplementedInLocalWorkspaceRepository } from "../repository/utils";
 import { localWorkspace } from "../repository/workspace";
 
@@ -19,13 +23,13 @@ const workspaces = async (
   { repository }: Context
 ) => await repository.workspace.list(args.where);
 
-const datasets = async (_parent: any, _args: any, { repository }: Context) => {
+const datasets = async (
+  _parent: never,
+  _args: never,
+  { repository }: Context
+) => {
   const queryResult = await repository.dataset.list();
-
-  return queryResult.map((datasetWithoutTypename) => ({
-    ...datasetWithoutTypename,
-    __typename: "Dataset",
-  }));
+  return addTypenames(queryResult, "Dataset");
 };
 
 export default {

--- a/typescript/web/src/connectors/resolvers/workspace.ts
+++ b/typescript/web/src/connectors/resolvers/workspace.ts
@@ -19,8 +19,13 @@ const workspaces = async (
   { repository }: Context
 ) => await repository.workspace.list(args.where);
 
-const datasets = (_parent: any, _args: any, { repository }: Context) => {
-  return repository.dataset.list();
+const datasets = async (_parent: any, _args: any, { repository }: Context) => {
+  const queryResult = await repository.dataset.list();
+
+  return queryResult.map((datasetWithoutTypename) => ({
+    ...datasetWithoutTypename,
+    __typename: "Dataset",
+  }));
 };
 
 export default {


### PR DESCRIPTION
## Work performed

- Made the `datasets` queries within a workspace to properly propagate their type, so that aggregate queries can properly know for which parent they are aggregating. 
