### PR TITLE
Increase default Cypress timeout to 60s

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,7 +1,7 @@
 {
   "projectId": "jmqq5y",
   "baseUrl": "http://localhost:3001",
-  "defaultCommandTimeout": 30000,
+  "defaultCommandTimeout": 60000,
   "retries": {
     "runMode": 2,
     "openMode": 0


### PR DESCRIPTION
## Work performed

<!--- Concisely describe what was done, this will appear in the public changelog -->
I've increased the Cypress default timeout to 60 seconds so that we can see if it reduces the amount of random e2e test failures.

## Results

<!--- Does this pull-request fully implement the new feature? If not why? Create and link new issues. -->
e2e tests will fail after 1mn instead of 30s

## Problems encountered

<!--- Explain problems that were encountered when implementing this pull-request -->
No

## Caveats

<!--- Any particular attention point with what you did? -->
It'll be slower to know that we did something wrong.

## Resolved issues

<!--- List references to issues that this PR resolves -->
Might resolve #730 

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
#742 (already opened during #740 )