### PR TITLE
Track click on a sign-in method and on manage billing

### DIFF
--- a/typescript/web/src/components/auth-manager/signin-button.tsx
+++ b/typescript/web/src/components/auth-manager/signin-button.tsx
@@ -1,12 +1,10 @@
-import React, { useCallback } from "react";
 import { Button, ButtonProps, useBreakpointValue } from "@chakra-ui/react";
+import React, { useCallback } from "react";
 import { useQueryParam } from "use-query-params";
 import { trackEvent } from "../../utils/google-analytics";
 import { BoolParam } from "../../utils/query-param-bool";
 
-type Props = ButtonProps;
-
-export const SigninButton = ({ ...props }: Props) => {
+export const SigninButton = ({ ...props }: ButtonProps) => {
   const [, setIsOpen] = useQueryParam("modal-signin", BoolParam);
 
   const handleOpen = useCallback(() => {

--- a/typescript/web/src/components/auth-manager/signin-modal/signin-modal.context.tsx
+++ b/typescript/web/src/components/auth-manager/signin-modal/signin-modal.context.tsx
@@ -15,6 +15,7 @@ import {
   useState,
 } from "react";
 import { StringParam, UrlUpdateType, useQueryParam } from "use-query-params";
+import { trackEvent } from "../../../utils/google-analytics";
 import { BoolParam } from "../../../utils/query-param-bool";
 import { validateEmail } from "../../../utils/validate-email";
 
@@ -72,12 +73,14 @@ const useSignInQuery = (): [SignInCallback, SignInResponse | undefined] => {
   const [response, setResponse] = useState<SignInResponse | undefined>();
   const handleSignIn = useCallback<SignInCallback>(
     async (method, options = {}) => {
+      trackEvent(`signin_${method}`, {});
       const callbackUrl = sanitizeUrl(window.location.toString());
-      const signInResponse = await signIn<SignInMethod>(method, {
+      const signInOptions: SignInOptions = {
         redirect: false,
         callbackUrl,
         ...options,
-      });
+      };
+      const signInResponse = await signIn<SignInMethod>(method, signInOptions);
       setResponse(signInResponse);
     },
     []

--- a/typescript/web/src/components/settings/workspace/billing.tsx
+++ b/typescript/web/src/components/settings/workspace/billing.tsx
@@ -1,38 +1,62 @@
 import { Button, Flex, Stack, Text } from "@chakra-ui/react";
+import { isNil } from "lodash/fp";
+import { useRouter } from "next/router";
+import { useCallback } from "react";
+import { trackEvent } from "../../../utils/google-analytics";
 import { Card } from "../card";
 import { FieldGroup } from "../field-group";
 import { HeadingGroup } from "../heading-group";
 import { useWorkspaceSettings } from "./context";
 
-export const Billing = () => {
-  const workspace = useWorkspaceSettings();
-  return (
-    <Stack as="section" spacing="6">
-      <HeadingGroup
-        title="Billing"
-        description="Change Plan, payment methods or billing information"
-      />
-      <Card>
-        <FieldGroup
-          title="Plan"
-          description="Your current plan. You can change it by clicking on Manage Billing"
-        >
-          <Text mt="1" mb="3">
-            {workspace?.plan}
-          </Text>
-        </FieldGroup>
+const Header = () => (
+  <HeadingGroup
+    title="Billing"
+    description="Change Plan, payment methods or billing information"
+  />
+);
 
-        <Flex direction="row" justifyContent="flex-end">
-          <Button
-            as="a"
-            href={workspace?.stripeCustomerPortalUrl ?? undefined}
-            size="sm"
-            colorScheme="brand"
-          >
-            Manage Billing
-          </Button>
-        </Flex>
-      </Card>
-    </Stack>
+const CurrentPlan = () => {
+  const { plan } = useWorkspaceSettings() ?? {};
+  return (
+    <FieldGroup
+      title="Plan"
+      description="Your current plan. You can change it by clicking on Manage Billing"
+    >
+      <Text mt="1" mb="3">
+        {plan}
+      </Text>
+    </FieldGroup>
   );
 };
+
+const ManageBillingButton = () => {
+  const { stripeCustomerPortalUrl } = useWorkspaceSettings() ?? {};
+  const router = useRouter();
+  const handleClick = useCallback(() => {
+    if (!isNil(stripeCustomerPortalUrl)) {
+      trackEvent("manage_billing", stripeCustomerPortalUrl);
+      router.push(stripeCustomerPortalUrl);
+    }
+  }, [router, stripeCustomerPortalUrl]);
+  return (
+    <Button size="sm" colorScheme="brand" onClick={handleClick}>
+      Manage Billing
+    </Button>
+  );
+};
+
+const Body = () => (
+  <Card>
+    <CurrentPlan />
+    <Flex direction="row" justifyContent="flex-end">
+      <ManageBillingButton />
+    </Flex>
+  </Card>
+);
+
+export const Billing = () => (
+  <Stack as="section" spacing="6">
+    <Header />
+    <Body />
+  </Stack>
+);


### PR DESCRIPTION
## Work performed

<!--- Concisely describe what was done, this will appear in the public changelog -->
I have:

* Added a `trackEvent` named `signin_${method}` which is called when we click on one of the `Sign in` buttons of the `SignInModal`
* Added a `trackEvent` named `manage_billing` which is called when we click on the `Manage billing` button of the workspace settings page.
* Factorized ImportButton and UserMenu while I was looking for existing events

## Results

<!--- Does this pull-request fully implement the new feature? If not why? Create and link new issues. -->
The `signin_${method}` and `manage_billing` events should appear in the analytics

## Problems encountered

<!--- Explain problems that were encountered when implementing this pull-request -->
* I had to match with the existing names (e.g. `signin` instead of `sign-in`).
* Some code is duplicated

## Caveats

<!--- Any particular attention point with what you did? -->
No

## Resolved issues

<!--- List references to issues that this PR resolves -->
Closes #733 

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
No