### PR TITLE
Fix exports not working from datasets in workspaces

### DIFF
--- a/typescript/common-resolvers/src/export/index.ts
+++ b/typescript/common-resolvers/src/export/index.ts
@@ -41,15 +41,14 @@ const exportDataset = async (
 ) => {
   const fileExport = await generateExportFile(args, { repository, req }, user);
   const origin = getOrigin(req);
-  const outUrl = (
+  const { uploadUrl, downloadUrl } =
     await repository.upload.getUploadTargetHttp(
       // FIXME make this Url disappear at some point...
       uuidv4(),
       origin
-    )
-  )?.uploadUrl;
-  await repository.upload.put(outUrl, fileExport, req);
-  return outUrl;
+    );
+  await repository.upload.put(uploadUrl, fileExport, req);
+  return downloadUrl;
 };
 
 export default {

--- a/typescript/web/src/components/export-button/export-modal/export-dataset.ts
+++ b/typescript/web/src/components/export-button/export-modal/export-dataset.ts
@@ -57,8 +57,10 @@ export const exportDataset = async ({
   const blobDataset = await (await fetch(exportDatasetUrl)).blob();
   const url = window.URL.createObjectURL(blobDataset);
   const element = document.createElement("a");
+  const extension =
+    format === ExportFormat.Yolo || options.coco?.exportImages ? "zip" : "json";
   element.href = url;
-  element.download = datasetName;
+  element.download = `${datasetName}.${extension}`;
   setIsExportRunning(false);
   element.click();
 };


### PR DESCRIPTION
## Work performed

- Fix exports from workspace datasets using the wrong URL (used the upload URL instead of the download URL).
- Fix downloaded files of exports having no extension. 

## Results

Exports from workspace datasets should now produce properly downloadable files.

## Resolved issues

Fixes #751  
