### PR TITLE
Configure the createLabelClass mutation when calling useMutation

### DIFF
--- a/typescript/web/src/components/dataset-classes/upsert-class-modal/create-label-class.mutation.ts
+++ b/typescript/web/src/components/dataset-classes/upsert-class-modal/create-label-class.mutation.ts
@@ -10,7 +10,6 @@ import { Query } from "@labelflow/graphql-types";
 import { getNextClassColor, LABEL_CLASS_COLOR_PALETTE } from "@labelflow/utils";
 import { useCallback } from "react";
 import { v4 as uuid } from "uuid";
-import { CREATE_WORKSPACE_MUTATION } from "../../workspace-switcher/create-workspace-modal/create-workspace.mutation";
 import { DATASET_LABEL_CLASSES_QUERY } from "./dataset-label-classes.query";
 
 export const CREATE_LABEL_CLASS_MUTATION = gql`
@@ -80,7 +79,7 @@ export const useCreateLabelClassMutation = (
   datasetId: string | undefined | null
 ): [() => Promise<void>, MutationResult<{}>] => {
   const client = useApolloClient();
-  const [createLabelClass, result] = useMutation(CREATE_WORKSPACE_MUTATION, {
+  const [createLabelClass, result] = useMutation(CREATE_LABEL_CLASS_MUTATION, {
     update: createLabelMutationUpdate(
       DATASET_LABEL_CLASSES_QUERY,
       datasetSlug,
@@ -101,7 +100,6 @@ export const useCreateLabelClassMutation = (
         ? LABEL_CLASS_COLOR_PALETTE[0]
         : getNextClassColor(labelClasses.map((labelClass) => labelClass.color));
     await createLabelClass({
-      mutation: CREATE_LABEL_CLASS_MUTATION,
       variables: { id: newClassId, name: className, color, datasetId },
       optimisticResponse: {
         createLabelClass: {


### PR DESCRIPTION
## Work performed

<!--- Concisely describe what was done, this will appear in the public changelog -->
In `create-label-class.mutation.ts` the `CREATE_WORKSPACE_MUTATION` was given as argument to the `useMutaion` used to create datasets. Hopefully `CREATE_DATASET_MUTATION` was given as argument to the call of the function generated by `useMutation` which prevented the code from having very weird errors.

Thanks @Jordanlelay for spotting the issue!

## Results

<!--- Does this pull-request fully implement the new feature? If not why? Create and link new issues. -->
It does not really fixes a bug as explained above but at least now the dependency-chain is correct.

## Problems encountered

<!--- Explain problems that were encountered when implementing this pull-request -->
I've pushed by mistake on `main` since the `Include administrators` protection rule had been unchecked. This is now fixed.

![image](https://user-images.githubusercontent.com/2091902/149342992-077bc31c-05d0-445a-82a7-3203b2626734.png)


## Caveats

<!--- Any particular attention point with what you did? -->
No

## Resolved issues

<!--- List references to issues that this PR resolves -->
No

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
No