### PR TITLE
Fix bug in getPaginatedImages where skip can be negative

### DIFF
--- a/typescript/web/src/components/dataset-images-list/images-list.context.tsx
+++ b/typescript/web/src/components/dataset-images-list/images-list.context.tsx
@@ -40,7 +40,8 @@ export const ImagesListProvider = ({
     variables: {
       datasetId,
       first: perPage,
-      skip: (page - 1) * perPage,
+      // If page is 0, skip becomes negative, which is forbidden
+      skip: Math.max((page - 1) * perPage, 0),
     },
     skip: !datasetSlug || !workspaceSlug || !datasetId,
   });


### PR DESCRIPTION
## Work performed

- Update getPaginatedImages query, avoiding skip parameter to be negative

## Results

No more 400 error if there is no image in a dataset

## Resolved issues

Closes #793 