### PR TITLE
Don't redirect to lastVisitedWorkspaceSlug anymore and remove local workspace from the switcher

### DIFF
--- a/typescript/web/src/components/layout/top-bar/user-menu.tsx
+++ b/typescript/web/src/components/layout/top-bar/user-menu.tsx
@@ -30,7 +30,6 @@ import { signOut, useSession } from "next-auth/react";
 import { gql, useQuery } from "@apollo/client";
 import { useRouter } from "next/router";
 import { useQueryParam } from "use-query-params";
-import { useCookies } from "react-cookie";
 import { BoolParam } from "../../../utils/query-param-bool";
 import { randomBackgroundGradient } from "../../../utils/random-background-gradient";
 import { getDisplayName } from "../../members/user";
@@ -62,10 +61,6 @@ export const UserMenu = () => {
   const { data: session, status } = useSession({ required: false });
 
   const [, setIsSigninOpen] = useQueryParam("modal-signin", BoolParam);
-
-  const removeLastVisitedWorkspaceSlugCookie = useCookies([
-    "lastVisitedWorkspaceSlug",
-  ])[2];
 
   const userInfoFromSession = session?.user;
 
@@ -162,13 +157,7 @@ export const UserMenu = () => {
               <>
                 <MenuItem
                   icon={<SignoutIcon fontSize="lg" />}
-                  onClick={() => {
-                    removeLastVisitedWorkspaceSlugCookie(
-                      "lastVisitedWorkspaceSlug",
-                      { path: "/", httpOnly: false }
-                    );
-                    signOut({ callbackUrl: "/" });
-                  }}
+                  onClick={() => signOut({ callbackUrl: "/" })}
                 >
                   Sign out
                 </MenuItem>

--- a/typescript/web/src/components/settings/workspace/danger-zone/delete-workspace.mutation.ts
+++ b/typescript/web/src/components/settings/workspace/danger-zone/delete-workspace.mutation.ts
@@ -2,7 +2,6 @@ import { ApolloCache, gql, useMutation } from "@apollo/client";
 import { Mutation } from "@labelflow/graphql-types";
 import { useRouter } from "next/router";
 import { useCallback } from "react";
-import { useCookies } from "react-cookie";
 import { useApolloErrorToast } from "../../../toast";
 import { useWorkspaceSettings } from "../context";
 
@@ -25,12 +24,10 @@ const useDeleteWorkspaceMutationUpdate = (workspaceId: string | undefined) => {
 };
 
 const useDeleteWorkspaceMutationComplete = () => {
-  const [, , removeCookie] = useCookies(["lastVisitedWorkspaceSlug"]);
   const router = useRouter();
   return useCallback(() => {
-    removeCookie("lastVisitedWorkspaceSlug", { path: "/", httpOnly: false });
     router.push(`/`);
-  }, [removeCookie, router]);
+  }, [router]);
 };
 
 export const useDeleteWorkspaceMutation = () => {

--- a/typescript/web/src/components/workspace-switcher/workspace-switcher.tsx
+++ b/typescript/web/src/components/workspace-switcher/workspace-switcher.tsx
@@ -1,14 +1,13 @@
 import { gql, useQuery } from "@apollo/client";
 import { Workspace } from "@labelflow/graphql-types";
+import { startCase } from "lodash/fp";
 import { useRouter } from "next/router";
-import { useState, useCallback, useMemo, useEffect } from "react";
-import { isNil, startCase } from "lodash/fp";
+import { useCallback, useMemo, useState } from "react";
 import { StringParam, useQueryParams } from "use-query-params";
-import { useCookies } from "react-cookie";
+import { BoolParam } from "../../utils/query-param-bool";
+import { CreateWorkspaceModal } from "./create-workspace-modal";
 import { WorkspaceMenu } from "./workspace-menu";
 import { WorkspaceItem } from "./workspace-menu/workspace-selection-popover";
-import { CreateWorkspaceModal } from "./create-workspace-modal";
-import { BoolParam } from "../../utils/query-param-bool";
 
 const getWorkspacesQuery = gql`
   query getWorkspaces {
@@ -23,22 +22,6 @@ const getWorkspacesQuery = gql`
 export const WorkspaceSwitcher = () => {
   const router = useRouter();
   const workspaceSlug = router?.query.workspaceSlug as string;
-
-  // Set cookie of last visited workspace if the user navigated to a new workspace
-  const [{ lastVisitedWorkspaceSlug }, setLastVisitedWorkspaceSlug] =
-    useCookies(["lastVisitedWorkspaceSlug"]);
-  useEffect(
-    () => {
-      if (!isNil(workspaceSlug) && lastVisitedWorkspaceSlug !== workspaceSlug) {
-        setLastVisitedWorkspaceSlug("lastVisitedWorkspaceSlug", workspaceSlug, {
-          path: "/",
-          httpOnly: false,
-        });
-      }
-    },
-    // We only want to call effect when current workspaceSlug has changed
-    [workspaceSlug]
-  );
 
   const [isOpen, setIsOpen] = useState(false);
 

--- a/typescript/web/src/components/workspace-switcher/workspace-switcher.tsx
+++ b/typescript/web/src/components/workspace-switcher/workspace-switcher.tsx
@@ -1,6 +1,5 @@
 import { gql, useQuery } from "@apollo/client";
 import { Workspace } from "@labelflow/graphql-types";
-import { startCase } from "lodash/fp";
 import { useRouter } from "next/router";
 import { useCallback, useMemo, useState } from "react";
 import { StringParam, useQueryParams } from "use-query-params";
@@ -36,7 +35,6 @@ export const WorkspaceSwitcher = () => {
 
   const workspaces: (Workspace & { src?: string })[] = useMemo(
     () => [
-      { id: "local", slug: "local", name: "Local", src: null },
       ...(getWorkspacesData?.workspaces ??
         getWorkspacesPreviousData?.workspaces ??
         []),
@@ -48,14 +46,7 @@ export const WorkspaceSwitcher = () => {
     if (workspaceSlug == null) {
       return null;
     }
-    if (workspaces == null) {
-      return {
-        id: "local",
-        slug: workspaceSlug,
-        name: startCase(workspaceSlug),
-        src: null,
-      };
-    }
+
     return workspaces.find(({ slug }) => slug === workspaceSlug);
   }, [workspaceSlug, workspaces]);
 

--- a/typescript/web/src/pages/[workspaceSlug]/index.tsx
+++ b/typescript/web/src/pages/[workspaceSlug]/index.tsx
@@ -28,7 +28,7 @@ const LocalDatasetsIndexPage = () => {
     <>
       <WelcomeModal />
       <AuthManager />
-      <Meta title="LabelFlow | Local Workspace" />
+      <Meta title="LabelFlow" />
       <CookieBanner />
       <Layout
         breadcrumbs={[<NavLogo key={0} />, <WorkspaceSwitcher key={1} />]}

--- a/typescript/web/src/pages/index.tsx
+++ b/typescript/web/src/pages/index.tsx
@@ -45,25 +45,7 @@ const IndexPage = () => {
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const parsedCookie = new Cookies(context.req.headers.cookie);
 
-  if (parsedCookie.get("hasUserTriedApp") === "true") {
-    const workspaceSlug = parsedCookie.get("lastVisitedWorkspaceSlug");
-    if (!isEmpty(workspaceSlug)) return { props: {} };
-    return {
-      props: {},
-      redirect: {
-        // Keep query params after redirect
-        destination: `/${workspaceSlug}/datasets${
-          isEmpty(context.query)
-            ? ""
-            : `?${join(
-                "&",
-                map(([key, value]) => `${key}=${value}`, toPairs(context.query))
-              )}`
-        }`,
-        permanent: false,
-      },
-    };
-  }
+  if (parsedCookie.get("hasUserTriedApp") === "true") return { props: {} };
 
   return {
     props: {},


### PR DESCRIPTION
## Work performed

- Remove lastVisitedWorkspace cookie
- Remove Local workspace from switcher

## Resolved issues

Closes #773
Closes #774 