### PR TITLE
Use a black dark theme

### DIFF
--- a/typescript/web/src/theme.ts
+++ b/typescript/web/src/theme.ts
@@ -13,6 +13,18 @@ export const theme = extendTheme({
   initialColorMode: "light",
   useSystemColorMode: true,
   colors: {
+    gray: {
+      "50": "#FEFEFE",
+      "100": "#D8D8D8",
+      "200": "#B2B2B2",
+      "300": "#8C8C8C",
+      "400": "#4D4D4D",
+      "500": "#37373D",
+      "600": "#333333",
+      "700": "#2A2D2E",
+      "800": "#252526",
+      "900": "#1E1E1E",
+    },
     brand: {
       "50": "#EAFAFA",
       "100": "#C5F1F0",


### PR DESCRIPTION
## Work performed

<!--- Concisely describe what was done, this will appear in the public changelog -->
I've changed the theme to that the dark theme is black and not blue as with (_nearly_) every dark themes.

This way, (_and because activating the dark theme depending on the system settings is a feature already handled by Chakra UI_), our design will fit better with the native dark theme we all have on our machines in 2022.

## Results

<!--- Does this pull-request fully implement the new feature? If not why? Create and link new issues. -->
See the preview Vercel deployment for results.

## Problems encountered

<!--- Explain problems that were encountered when implementing this pull-request -->
The way the dark theme is made blue in Chakra UI is by using blue colors in the `gray` variants !?! 🤯 

## Caveats

<!--- Any particular attention point with what you did? -->
Those who prefer blue won't be happy. As with 99% of the dark themes in the world...

## Resolved issues

<!--- List references to issues that this PR resolves -->
This will ease the Monaco editor integration since the colors will fits the default ones.

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
No