### PR TITLE
Make pagination footer ignore its parent padding

### DIFF
--- a/typescript/web/src/components/pagination/pagination-footer.tsx
+++ b/typescript/web/src/components/pagination/pagination-footer.tsx
@@ -5,7 +5,9 @@ export const PaginationFooter = () => {
   const { itemCount } = usePagination();
   return (
     <>
-      {itemCount > 0 && <PaginationToolbar pos="fixed" bottom={0} w="100%" />}
+      {itemCount > 0 && (
+        <PaginationToolbar pos="fixed" bottom={0} w="100%" left={0} />
+      )}
     </>
   );
 };


### PR DESCRIPTION
## Work performed

- Fix bug on datasets pagination

## Results

Add a left directive on pagination to override potential padding inherited from parent