### PR TITLE
In website, use ghost variant on the GitHub button

### DIFF
--- a/typescript/web/src/components/website/Navbar/NavContent.tsx
+++ b/typescript/web/src/components/website/Navbar/NavContent.tsx
@@ -32,7 +32,7 @@ const GitHubButton = ({ isMobile }: { isMobile?: boolean }) => {
       rel="noreferrer"
     >
       <Button
-        variant={isMobile ? "outline" : "link"}
+        variant={isMobile ? "outline" : "ghost"}
         aria-label={label}
         leftIcon={<StarIcon fontSize="2xl" />}
         {...mobileProps}

--- a/typescript/web/src/components/website/Navbar/NavContent.tsx
+++ b/typescript/web/src/components/website/Navbar/NavContent.tsx
@@ -5,7 +5,6 @@ import {
   Flex,
   FlexProps,
   HStack,
-  Link,
   Spacer,
   useDisclosure,
   VisuallyHidden,
@@ -26,12 +25,11 @@ const GitHubButton = ({ isMobile }: { isMobile?: boolean }) => {
   const label = "Star us on GitHub";
   const mobileProps = isMobile ? { w: "full", size: "lg", mt: "5" } : {};
   return (
-    <Link
-      href="https://github.com/labelflow/labelflow"
-      target="_blank"
-      rel="noreferrer"
-    >
+    <NextLink href="https://github.com/labelflow/labelflow" passHref>
       <Button
+        as="a"
+        target="_blank"
+        rel="noreferrer"
         variant={isMobile ? "outline" : "ghost"}
         aria-label={label}
         leftIcon={<StarIcon fontSize="2xl" />}
@@ -39,7 +37,7 @@ const GitHubButton = ({ isMobile }: { isMobile?: boolean }) => {
       >
         {label}
       </Button>
-    </Link>
+    </NextLink>
   );
 };
 
@@ -127,11 +125,7 @@ const DesktopNavContent = (props: FlexProps) => {
           </Box>
         ))}
       </HStack>
-      <HStack
-        spacing="4"
-        //  minW="240px"
-        justify="space-between"
-      >
+      <HStack spacing="4" justify="space-between" align="center">
         <GitHubButton />
         <NextLink href="/local/datasets">
           <Button


### PR DESCRIPTION
## Work performed

<!--- Concisely describe what was done, this will appear in the public changelog -->
I've changed the look of the "Star us on GitHub" button on the website so that it matches the shape of the "Try it now" button when hovered

## Results

<!--- Doves this pull-request fully implement the new feature? If not why? Create and link new issues. -->
The GitHub button now fits better with the "Try it now button" when hovered

## Problems encountered

<!--- Explain problems that were encountered when implementing this pull-request -->
No

## Caveats

<!--- Any particular attention point with what you did? -->
https://github.com/labelflow/labelflow/issues/759#issuecomment-1008924997

## Resolved issues

<!--- List references to issues that this PR resolves -->
No

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
No