### PR TITLE
Improve image upload performance

### DIFF
--- a/typescript/common-resolvers/src/utils/__tests__/thumbnail-url.ts
+++ b/typescript/common-resolvers/src/utils/__tests__/thumbnail-url.ts
@@ -19,6 +19,8 @@ it("Simple case", async () => {
     size: 500,
     extension: "jpeg",
     url: "https://example.com/image.jpg",
+    urlPrefix: "https://example.com/",
+    urlSuffix: "image.jpg",
   });
 });
 
@@ -38,6 +40,8 @@ it("Corner case 1", async () => {
     size: 12,
     extension: "png",
     url: "/coucou/176371/loulou/image.jpeg.gif",
+    urlPrefix: "/coucou/176371/loulou/",
+    urlSuffix: "image.jpeg.gif",
   });
 });
 
@@ -55,5 +59,7 @@ it("Corner case 2", async () => {
     size: 43,
     extension: "png",
     url: "ffds.jpeg.gif",
+    urlPrefix: undefined,
+    urlSuffix: "ffds.jpeg.gif",
   });
 });

--- a/typescript/common-resolvers/src/utils/thumbnail-url.ts
+++ b/typescript/common-resolvers/src/utils/thumbnail-url.ts
@@ -1,18 +1,18 @@
+export type ImageUrlInfo = {
+  size: number;
+  extension: string;
+  url: string;
+};
+
 export const getThumbnailUrlFromImageUrl = ({
   size,
   extension = "jpeg",
   url,
-}: {
-  size: number;
-  extension: string;
-  url: string;
-}) => {
+}: ImageUrlInfo): string => {
   const urlLastSlash = url.lastIndexOf("/");
   const urlPrefix = url.substring(0, urlLastSlash + 1);
   const urlSuffix = url.substring(urlLastSlash + 1);
-
-  const thumbnailUrl = `${urlPrefix}thumbnails/${size}/${urlSuffix}.${extension}`;
-  return thumbnailUrl;
+  return `${urlPrefix}thumbnails/${size}/${urlSuffix}.${extension}`;
 };
 
 const urlRegex =
@@ -20,20 +20,12 @@ const urlRegex =
 
 export const getImageUrlFromThumbnailUrl = (
   url: string
-): {
-  size: number;
-  extension: string;
-  url: string;
-} | null => {
+): ImageUrlInfo | null => {
   const result: any | null = url.match(urlRegex)?.groups;
-
-  if (!result) {
-    return null;
-  }
-
+  if (!result) return null;
   return {
+    ...result,
     size: parseInt(result.size as string, 10),
-    extension: result.extension,
     url: `${result.urlPrefix ?? ""}${result.urlSuffix}`,
   };
 };

--- a/typescript/db/package.json
+++ b/typescript/db/package.json
@@ -45,6 +45,7 @@
     "memoize-one": "^5.2.1",
     "slugify": "^1.6.0",
     "stripe": "^8.184.0",
+    "type-fest": "^2.10.0",
     "uuid": "8.3.2"
   }
 }

--- a/typescript/db/src/repository/image-processing.ts
+++ b/typescript/db/src/repository/image-processing.ts
@@ -1,33 +1,40 @@
-import Blob from "fetch-blob";
-
-import { getThumbnailUrlFromImageUrl } from "@labelflow/common-resolvers/src/utils/thumbnail-url";
-import Jimp from "jimp/es";
 import type { Repository, ThumbnailSizes } from "@labelflow/common-resolvers";
+import {
+  getThumbnailUrlFromImageUrl,
+  ImageUrlInfo,
+} from "@labelflow/common-resolvers/src/utils/thumbnail-url";
+import Blob from "fetch-blob";
+import Jimp from "jimp/es";
+import { isEmpty, isNil } from "lodash/fp";
+import { AsyncReturnType } from "type-fest";
 
 globalThis.Blob = Blob;
 
-const defaultMaxImageSizePixel: number = 60e6;
-const maxImageSizePixel: { [mimetype: string]: number } = {
+type ProcessImageResolver = Repository["imageProcessing"]["processImage"];
+type ProcessImageInput = Parameters<ProcessImageResolver>[0];
+type PutImageCallback = Parameters<ProcessImageResolver>[2];
+type ProcessImageResult = AsyncReturnType<ProcessImageResolver>;
+
+const DEFAULT_MAX_IMAGE_SIZE_PX: number = 60e6;
+const MAX_IMAGE_SIZES_PX: { [mimetype: string]: number } = {
   "image/jpeg": 100e6,
   "image/png": 60e6,
+};
+
+type ImageSize = {
+  width: number;
+  height: number;
+  mimetype: string;
 };
 
 const validateImageSize = ({
   width,
   height,
   mimetype,
-}: {
-  width: number;
-  height: number;
-  mimetype: string;
-}): {
-  width: number;
-  height: number;
-  mimetype: string;
-} => {
+}: ImageSize): ImageSize => {
   const imageSize = width * height;
-  const maxImageSize: number =
-    maxImageSizePixel?.[mimetype] ?? defaultMaxImageSizePixel;
+  const maxImageSize =
+    MAX_IMAGE_SIZES_PX?.[mimetype] ?? DEFAULT_MAX_IMAGE_SIZE_PX;
   if (imageSize > maxImageSize) {
     throw new Error(`
     Image is too big! Dimensions are ${width} x ${height} = ${Math.round(
@@ -35,11 +42,14 @@ const validateImageSize = ({
     )}Mpx while limit is ${Math.round(maxImageSize * 1e-6)}Mpx
     `);
   }
-  return {
-    width,
-    height,
-    mimetype,
-  };
+  return { width, height, mimetype };
+};
+
+type GenerateThumbnailOptions = {
+  image: Jimp;
+  url: string;
+  size: ThumbnailSizes;
+  putThumbnail: PutImageCallback;
 };
 
 /**
@@ -50,105 +60,111 @@ const generateThumbnail = async ({
   image,
   url,
   size,
-  putImage,
-}: {
-  image: Jimp;
-  url: string;
-  size: ThumbnailSizes;
-  putImage: (url: string, blob: Blob) => Promise<void>;
-}): Promise<{ url: string; image?: Jimp }> => {
+  putThumbnail,
+}: GenerateThumbnailOptions): Promise<[string, Jimp | undefined]> => {
   try {
-    const thumbnailUrl = getThumbnailUrlFromImageUrl({
-      url,
-      size,
-      extension: "jpeg",
-    });
+    const urlInfo: ImageUrlInfo = { url, size, extension: "jpeg" };
+    const thumbnailUrl = getThumbnailUrlFromImageUrl(urlInfo);
     const jimpThumbnail = image
       .clone()
       .scaleToFit(size, size, Jimp.RESIZE_BILINEAR);
-    const vipsThumbnail = await jimpThumbnail.getBufferAsync("image/jpeg");
-
-    await putImage(
-      thumbnailUrl,
-      new Blob([vipsThumbnail], { type: "image/jpeg" })
-    );
-    return {
-      url: thumbnailUrl,
-      image: jimpThumbnail,
-    };
+    const buffer = await jimpThumbnail.getBufferAsync("image/jpeg");
+    const blob = new Blob([buffer], { type: "image/jpeg" });
+    await putThumbnail(thumbnailUrl, blob);
+    return [thumbnailUrl, jimpThumbnail];
   } catch (e) {
     console.error(e);
-    return { url };
+    return [url, undefined];
   }
+};
+
+type GenerateThumbnailFromSizeOptions = {
+  thumbnailUrl?: string;
+} & Pick<GenerateThumbnailOptions, "url" | "image" | "putThumbnail" | "size">;
+
+const generateThumbnailFromSize = async ({
+  thumbnailUrl,
+  ...options
+}: GenerateThumbnailFromSizeOptions): Promise<string> => {
+  if (!isNil(thumbnailUrl) && !isEmpty(thumbnailUrl)) return thumbnailUrl;
+  const [result] = await generateThumbnail(options);
+  return result;
+};
+
+type ThumbnailsKeys =
+  | "thumbnail20Url"
+  | "thumbnail50Url"
+  | "thumbnail100Url"
+  | "thumbnail200Url"
+  | "thumbnail500Url";
+
+type GenerateThumbnailsOptions = Pick<
+  GenerateThumbnailOptions,
+  "image" | "url" | "putThumbnail"
+> &
+  Pick<ProcessImageInput, ThumbnailsKeys>;
+
+type GenerateThumbnailsResult = Pick<ProcessImageResult, ThumbnailsKeys>;
+
+const generateThumbnails = async ({
+  image,
+  url,
+  thumbnail20Url,
+  thumbnail50Url,
+  thumbnail100Url,
+  thumbnail200Url,
+  thumbnail500Url,
+  putThumbnail,
+}: GenerateThumbnailsOptions): Promise<GenerateThumbnailsResult> => {
+  // Generate a first lower-res thumbnail so that the next ones will be faster
+  // to downscale
+  const [thumbnail500UrlNew, imageSrc] = thumbnail500Url
+    ? [thumbnail500Url, image]
+    : await generateThumbnail({ size: 500, image, url, putThumbnail });
+  const thumbnailsToGen: { url?: string | null; size: ThumbnailSizes }[] = [
+    { url: thumbnail20Url, size: 20 },
+    { url: thumbnail50Url, size: 50 },
+    { url: thumbnail100Url, size: 100 },
+    { url: thumbnail200Url, size: 200 },
+    { url: thumbnail500UrlNew, size: 500 },
+  ];
+  const generatedThumbnailUrls = await Promise.all(
+    thumbnailsToGen.map((options) =>
+      generateThumbnailFromSize({
+        thumbnailUrl: options.url ?? undefined,
+        size: options.size,
+        image: imageSrc ?? image,
+        putThumbnail,
+        url,
+      })
+    )
+  );
+  return {
+    thumbnail20Url: generatedThumbnailUrls[0],
+    thumbnail50Url: generatedThumbnailUrls[1],
+    thumbnail100Url: generatedThumbnailUrls[2],
+    thumbnail200Url: generatedThumbnailUrls[3],
+    thumbnail500Url: generatedThumbnailUrls[4],
+  };
 };
 
 /**
  * Given a partial image, return a completed version of the image, probing it if necessary
  */
 export const processImage: Repository["imageProcessing"]["processImage"] =
-  async (
-    {
-      width,
-      height,
-      mimetype,
-      url,
-      thumbnail20Url,
-      thumbnail50Url,
-      thumbnail100Url,
-      thumbnail200Url,
-      thumbnail500Url,
-    },
-    getImage,
-    putImage
-  ) => {
+  async (input, getImage, putThumbnail) => {
+    const { url, width, height, mimetype } = input;
     const buffer = await getImage(url);
     const image = await Jimp.read(buffer as Buffer);
-
-    const { url: thumbnail500UrlNew, image: imageSrc } = thumbnail500Url
-      ? { url: thumbnail500Url, image }
-      : ((await generateThumbnail({ size: 500, image, url, putImage })) as {
-          url: string;
-          image: Jimp;
-        });
-
-    const generateThumbnailFromSize = async (
-      thumbUrl: string | null | undefined,
-      size: ThumbnailSizes
-    ) =>
-      thumbUrl ??
-      (
-        await generateThumbnail({
-          size,
-          image: imageSrc,
-          url,
-          putImage,
-        })
-      ).url;
-
-    const thumbnailsToGen: { url?: string | null; size: ThumbnailSizes }[] = [
-      { url: thumbnail20Url, size: 20 },
-      { url: thumbnail50Url, size: 50 },
-      { url: thumbnail100Url, size: 100 },
-      { url: thumbnail200Url, size: 200 },
-      { url: thumbnail500UrlNew, size: 500 },
-    ];
-
-    const generatedThumbnailUrls = await Promise.all(
-      thumbnailsToGen.map((thumbGenInfo) =>
-        generateThumbnailFromSize(thumbGenInfo.url, thumbGenInfo.size)
-      )
-    );
-
-    return {
-      ...validateImageSize({
-        width: width ?? image.bitmap.width,
-        height: height ?? image.bitmap.height,
-        mimetype: mimetype ?? image.getMIME(),
-      }),
-      thumbnail20Url: generatedThumbnailUrls[0],
-      thumbnail50Url: generatedThumbnailUrls[1],
-      thumbnail100Url: generatedThumbnailUrls[2],
-      thumbnail200Url: generatedThumbnailUrls[3],
-      thumbnail500Url: generatedThumbnailUrls[4],
-    };
+    const thumbnails = await generateThumbnails({
+      ...input,
+      image,
+      putThumbnail,
+    });
+    const size = validateImageSize({
+      width: width ?? image.bitmap.width,
+      height: height ?? image.bitmap.height,
+      mimetype: mimetype ?? image.getMIME(),
+    });
+    return { ...size, ...thumbnails };
   };

--- a/typescript/web/src/components/import-button/import-images-modal/constants.ts
+++ b/typescript/web/src/components/import-button/import-images-modal/constants.ts
@@ -8,7 +8,7 @@
  * (thumbnails generations & size validation) of the created all images.
  * If we the batch size, the "createManyImages" mutation will take longer to resolve.
  */
-export const BATCH_SIZE = 10;
+export const BATCH_SIZE = 2;
 
 /**
  * Maximum number of batches to perform in parallel.
@@ -20,4 +20,4 @@ export const BATCH_SIZE = 10;
  * However, increasing this number will also increase the number
  * of connections to the database.
  */
-export const CONCURRENCY = 2;
+export const CONCURRENCY = 20;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6682,6 +6682,7 @@ __metadata:
     slugify: ^1.6.0
     stripe: ^8.184.0
     ts-node: 10.1.0
+    type-fest: ^2.10.0
     typescript: 4.3.5
     uuid: 8.3.2
   languageName: unknown
@@ -33113,6 +33114,13 @@ service-worker-mock@2.0.5:
   version: 0.8.1
   resolution: "type-fest@npm:0.8.1"
   checksum: d61c4b2eba24009033ae4500d7d818a94fd6d1b481a8111612ee141400d5f1db46f199c014766b9fa9b31a6a7374d96fc748c6d688a78a3ce5a33123839becb7
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^2.10.0":
+  version: 2.10.0
+  resolution: "type-fest@npm:2.10.0"
+  checksum: a14df0691efc38fe2d0c88ed28182a979c662b71b9e9776638cbaf0ba081f5afcd95ce23c3085f67367a5555b1984b6db828df57cf3b2ae2d61c01b10fa5bc40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Work performed

- Update image batch size and amount for avoiding timeouts when uploading: was 2 batches of 10, now is 20 batches of 2.
- Enhance thumbnail generation performance using parallelisation and generating smaller thumbnail sizes on the largest one, instead of the original image.

## Results

We can now upload several images without experiencing timeouts

## Problems encountered

<!--- Explain problems that were encountered when implementing this pull-request -->

## Caveats

There is a limitation on the size of the image we can upload. I tried to upload the image `LargeImageTest.png` from our `very large images` dataset which is 23.6 Mo and it fails rather quickly with an `Array buffer allocation failed` error. 

It most likely comes from the serverless function that runs out of memory, probably when Jimp try to read the image.

The image is at a resolution of 8000x10000 (80M pixels) which should be handled by our `validateImageSize` function that is supposed to reject `.png` images bigger than 60M pixels.

## Resolved issues

<!--- List references to issues that this PR resolves -->

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
