### PR TITLE
Update memory value of graphql's serverless function

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,15 @@
   "trailingSlash": false,
   "github": {
     "enabled": true
+  },
+  "functions": {
+    "pages/api/graphql.ts": {
+      "memory": 3008,
+      "maxDuration": 60
+    },
+    "api/graphql.ts": {
+      "memory": 3008,
+      "maxDuration": 60
+    }
   }
 }


### PR DESCRIPTION
## Work performed

- Bump memory of `pages/api/graphql` from 1024 (default) to 3008