### PR TITLE
Name client-side GraphQL queries and mutations with PascalCase and type suffix

### DIFF
--- a/typescript/web/src/components/dataset-classes/__tests__/upsert-class-modal.test.tsx
+++ b/typescript/web/src/components/dataset-classes/__tests__/upsert-class-modal.test.tsx
@@ -88,7 +88,7 @@ const createLabelClassInTestDataset = async ({
     },
   } = await client.mutate({
     mutation: gql`
-      mutation createLabelClassMutation(
+      mutation CreateLabelClassMutation(
         $id: ID!
         $name: String!
         $color: ColorHex!
@@ -189,7 +189,7 @@ describe("UpsertClassModal", () => {
         data: { labelClasses },
       } = await client.query({
         query: gql`
-          query getLabelClasses {
+          query GetLabelClassesQuery {
             labelClasses {
               id
               name

--- a/typescript/web/src/components/dataset-classes/__tests__/upsert-class-modal.test.tsx
+++ b/typescript/web/src/components/dataset-classes/__tests__/upsert-class-modal.test.tsx
@@ -88,7 +88,7 @@ const createLabelClassInTestDataset = async ({
     },
   } = await client.mutate({
     mutation: gql`
-      mutation CreateLabelClassMutation(
+      mutation CreateLabelClassInTestDatasetMutation(
         $id: ID!
         $name: String!
         $color: ColorHex!

--- a/typescript/web/src/components/dataset-classes/dataset-classes.query.ts
+++ b/typescript/web/src/components/dataset-classes/dataset-classes.query.ts
@@ -2,7 +2,7 @@ import { gql, useQuery } from "@apollo/client";
 import { DatasetClassesQueryResult } from "./types";
 
 export const DATASET_LABEL_CLASSES_QUERY_WITH_COUNT = gql`
-  query getDatasetLabelClassesWithTotalCount(
+  query GetDatasetLabelClassesWithTotalCountQuery(
     $workspaceSlug: String!
     $datasetSlug: String!
   ) {
@@ -38,7 +38,7 @@ export const useDatasetLabelClassesQuery = (
 };
 
 export const GET_LABEL_CLASS_BY_ID_QUERY = gql`
-  query getLabelClassById($id: ID!) {
+  query GetLabelClassByIdQuery($id: ID!) {
     labelClass(where: { id: $id }) {
       id
       name

--- a/typescript/web/src/components/dataset-classes/delete-label-class-modal.tsx
+++ b/typescript/web/src/components/dataset-classes/delete-label-class-modal.tsx
@@ -23,7 +23,7 @@ import {
 } from "./dataset-classes.query";
 
 const DELETE_LABEL_CLASS_MUTATION = gql`
-  mutation deleteLabelClass($id: ID!) {
+  mutation DeleteLabelClassMutation($id: ID!) {
     deleteLabelClass(where: { id: $id }) {
       id
     }

--- a/typescript/web/src/components/dataset-classes/reorder-label-class.mutation.ts
+++ b/typescript/web/src/components/dataset-classes/reorder-label-class.mutation.ts
@@ -1,7 +1,7 @@
 import { gql, useMutation } from "@apollo/client";
 
 export const REORDER_LABEL_CLASS_MUTATION = gql`
-  mutation reorderLabelClass($id: ID!, $index: Int!) {
+  mutation ReorderLabelClassMutation($id: ID!, $index: Int!) {
     reorderLabelClass(where: { id: $id }, data: { index: $index }) {
       id
     }

--- a/typescript/web/src/components/dataset-classes/upsert-class-modal/create-label-class.mutation.ts
+++ b/typescript/web/src/components/dataset-classes/upsert-class-modal/create-label-class.mutation.ts
@@ -13,7 +13,7 @@ import { v4 as uuid } from "uuid";
 import { DATASET_LABEL_CLASSES_QUERY } from "./dataset-label-classes.query";
 
 export const CREATE_LABEL_CLASS_MUTATION = gql`
-  mutation createLabelClass(
+  mutation CreateLabelClassMutation(
     $id: ID
     $name: String!
     $color: ColorHex

--- a/typescript/web/src/components/dataset-classes/upsert-class-modal/dataset-label-classes.query.ts
+++ b/typescript/web/src/components/dataset-classes/upsert-class-modal/dataset-label-classes.query.ts
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client";
 
 export const DATASET_LABEL_CLASSES_QUERY = gql`
-  query getDatasetLabelClasses($slug: String!, $workspaceSlug: String!) {
+  query GetDatasetLabelClassesQuery($slug: String!, $workspaceSlug: String!) {
     dataset(where: { slugs: { slug: $slug, workspaceSlug: $workspaceSlug } }) {
       id
       name

--- a/typescript/web/src/components/dataset-classes/upsert-class-modal/label-class-exists.query.ts
+++ b/typescript/web/src/components/dataset-classes/upsert-class-modal/label-class-exists.query.ts
@@ -3,7 +3,7 @@ import { Query, QueryLabelClassExistsArgs } from "@labelflow/graphql-types";
 import { useDebounce } from "use-debounce";
 
 export const LABEL_CLASS_EXISTS_QUERY = gql`
-  query labelClassExists($datasetId: ID!, $name: String!) {
+  query LabelClassExistsQuery($datasetId: ID!, $name: String!) {
     labelClassExists(where: { datasetId: $datasetId, name: $name })
   }
 `;

--- a/typescript/web/src/components/dataset-classes/upsert-class-modal/update-label-class-name.mutation.ts
+++ b/typescript/web/src/components/dataset-classes/upsert-class-modal/update-label-class-name.mutation.ts
@@ -2,7 +2,7 @@ import { gql, MutationResult, useMutation } from "@apollo/client";
 import { useCallback } from "react";
 
 export const UPDATE_LABEL_CLASS_NAME_MUTATION = gql`
-  mutation updateLabelClassName($id: ID!, $name: String!) {
+  mutation UpdateLabelClassNameMutation($id: ID!, $name: String!) {
     updateLabelClass(where: { id: $id }, data: { name: $name }) {
       id
       name

--- a/typescript/web/src/components/dataset-images-list/delete-image-modal.tsx
+++ b/typescript/web/src/components/dataset-images-list/delete-image-modal.tsx
@@ -16,7 +16,7 @@ import {
 import { DATASET_DATA_QUERY } from "../../pages/[workspaceSlug]/datasets/[datasetSlug]/images";
 
 const GET_IMAGE_BY_ID_QUERY = gql`
-  query getImageById($id: ID!) {
+  query GetImageByIdQuery($id: ID!) {
     image(where: { id: $id }) {
       id
       name
@@ -25,7 +25,7 @@ const GET_IMAGE_BY_ID_QUERY = gql`
 `;
 
 const DELETE_IMAGE_MUTATION = gql`
-  mutation deleteImage($id: ID!) {
+  mutation DeleteImageMutation($id: ID!) {
     deleteImage(where: { id: $id }) {
       id
     }

--- a/typescript/web/src/components/dataset-images-list/paginated-images-query.ts
+++ b/typescript/web/src/components/dataset-images-list/paginated-images-query.ts
@@ -9,7 +9,7 @@ import { useCallback } from "react";
 import { ImagesQueryCache } from "../../connectors/apollo-client/cache-config";
 
 export const PAGINATED_IMAGES_QUERY = gql`
-  query paginatedImagesQuery($datasetId: ID!, $first: Int!, $skip: Int!) {
+  query PaginatedImagesQuery($datasetId: ID!, $first: Int!, $skip: Int!) {
     images(where: { datasetId: $datasetId }, first: $first, skip: $skip) {
       id
       name

--- a/typescript/web/src/components/datasets/__tests__/upsert-dataset-modal.tsx
+++ b/typescript/web/src/components/datasets/__tests__/upsert-dataset-modal.tsx
@@ -91,7 +91,7 @@ test("should create a dataset when the form is submitted", async () => {
     },
   } = await client.query({
     query: gql`
-      query getDatasetByName($slug: String!) {
+      query GetDatasetByNameQuery($slug: String!) {
         dataset(where: { slugs: { slug: $slug, workspaceSlug: "local" } }) {
           slug
         }

--- a/typescript/web/src/components/datasets/datasets.query.ts
+++ b/typescript/web/src/components/datasets/datasets.query.ts
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client";
 
 export const GET_DATASET_BY_ID_QUERY = gql`
-  query getDatasetById($id: ID) {
+  query GetDatasetByIdQuery($id: ID) {
     dataset(where: { id: $id }) {
       id
       name
@@ -10,7 +10,7 @@ export const GET_DATASET_BY_ID_QUERY = gql`
 `;
 
 export const SEARCH_DATASET_BY_SLUG_QUERY = gql`
-  query searchDatasetBySlug($slug: String!, $workspaceSlug: String!) {
+  query SearchDatasetBySlugQuery($slug: String!, $workspaceSlug: String!) {
     searchDataset(
       where: { slugs: { slug: $slug, workspaceSlug: $workspaceSlug } }
     ) {
@@ -21,7 +21,7 @@ export const SEARCH_DATASET_BY_SLUG_QUERY = gql`
 `;
 
 export const GET_DATASET_BY_SLUG_QUERY = gql`
-  query getDatasetBySlug($slug: String!, $workspaceSlug: String!) {
+  query GetDatasetBySlugQuery($slug: String!, $workspaceSlug: String!) {
     dataset(where: { slugs: { slug: $slug, workspaceSlug: $workspaceSlug } }) {
       id
       name

--- a/typescript/web/src/components/datasets/delete-dataset-modal.tsx
+++ b/typescript/web/src/components/datasets/delete-dataset-modal.tsx
@@ -13,7 +13,7 @@ import { GET_DATASETS_QUERY } from "../../utils/shared-queries";
 import { GET_DATASET_BY_ID_QUERY } from "./datasets.query";
 
 const DELETE_DATASET_BY_ID_MUTATION = gql`
-  mutation deleteDatasetById($id: ID!) {
+  mutation DeleteDatasetByIdMutation($id: ID!) {
     deleteDataset(where: { id: $id }) {
       id
     }

--- a/typescript/web/src/components/datasets/upsert-dataset-modal.tsx
+++ b/typescript/web/src/components/datasets/upsert-dataset-modal.tsx
@@ -27,7 +27,7 @@ import {
 const debounceTime = 200;
 
 const CREATE_DATASET_MUTATION = gql`
-  mutation createDataset($name: String!, $workspaceSlug: String!) {
+  mutation CreateDatasetMutation($name: String!, $workspaceSlug: String!) {
     createDataset(data: { name: $name, workspaceSlug: $workspaceSlug }) {
       id
     }
@@ -35,7 +35,7 @@ const CREATE_DATASET_MUTATION = gql`
 `;
 
 const UPDATE_DATASET_MUTATION = gql`
-  mutation updateDataset($id: ID!, $name: String!) {
+  mutation UpdateDatasetMutation($id: ID!, $name: String!) {
     updateDataset(where: { id: $id }, data: { name: $name }) {
       id
     }

--- a/typescript/web/src/components/export-button/export-modal/export-dataset.ts
+++ b/typescript/web/src/components/export-button/export-modal/export-dataset.ts
@@ -3,7 +3,7 @@ import { ExportFormat, ExportOptions } from "@labelflow/graphql-types";
 import { Dispatch, SetStateAction } from "react";
 
 const EXPORT_QUERY = gql`
-  query exportDatasetUrl(
+  query ExportDatasetUrlQuery(
     $datasetId: ID!
     $format: ExportFormat!
     $options: ExportOptions

--- a/typescript/web/src/components/export-button/export-modal/export-modal.context.tsx
+++ b/typescript/web/src/components/export-button/export-modal/export-modal.context.tsx
@@ -12,7 +12,7 @@ import {
 import { useRouter } from "next/router";
 
 export const COUNT_LABELS_OF_DATASET_QUERY = gql`
-  query countLabelsOfDataset($slug: String!, $workspaceSlug: String!) {
+  query CountLabelsOfDatasetQuery($slug: String!, $workspaceSlug: String!) {
     dataset(where: { slugs: { slug: $slug, workspaceSlug: $workspaceSlug } }) {
       id
       imagesAggregates {

--- a/typescript/web/src/components/home/home.tsx
+++ b/typescript/web/src/components/home/home.tsx
@@ -14,7 +14,7 @@ import { LayoutSpinner } from "../spinner";
 import { CreateWorkspaceModal } from "../workspace-switcher/create-workspace-modal";
 
 export const GET_HOME_WORKSPACES_QUERY = gql`
-  query getHomeWorkspaces {
+  query GetHomeWorkspacesQuery {
     workspaces {
       id
       name

--- a/typescript/web/src/components/import-button/__tests__/import-button.tsx
+++ b/typescript/web/src/components/import-button/__tests__/import-button.tsx
@@ -107,7 +107,7 @@ test("should clear the modal content when closed", async () => {
   );
 
   expect(client.refetchQueries).toHaveBeenNthCalledWith(2, {
-    include: ["paginatedImagesQuery"],
+    include: ["PaginatedImagesQuery"],
   });
   expect(client.mutate).toHaveBeenCalled();
 });

--- a/typescript/web/src/components/import-button/import-images-modal/import-images-modal.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/import-images-modal.tsx
@@ -51,7 +51,7 @@ export const ImportImagesModal = ({
         fetchPolicy: "network-only",
       });
       client.query({ query: GET_DATASETS_QUERY, fetchPolicy: "network-only" });
-      client.refetchQueries({ include: ["paginatedImagesQuery"] });
+      client.refetchQueries({ include: ["PaginatedImagesQuery"] });
     }
   }, [hasUploaded]);
 

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/import-datasets.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/import-datasets.tsx
@@ -10,7 +10,7 @@ import { DroppedFile, SetUploadStatuses } from "../../types";
 import { CONCURRENCY } from "../../constants";
 
 const IMPORT_DATASET_MUTATION = gql`
-  mutation importDataset(
+  mutation ImportDatasetMutation(
     $where: DatasetWhereUniqueInput!
     $data: DatasetImportInput!
   ) {
@@ -52,12 +52,12 @@ const importDataset = async ({
       },
     },
     refetchQueries: [
-      "getDatasetData",
-      "getImageLabels",
-      "getLabel",
-      "countLabelsOfDataset",
-      "getDatasetLabelClasses",
-      "getDatasetLabelClassesWithTotalCount",
+      "GetDatasetDataQuery",
+      "GetImageLabelsQuery",
+      "GetLabelQuery",
+      "CountLabelsOfDatasetQuery",
+      "GetDatasetLabelClassesQuery",
+      "GetDatasetLabelClassesWithTotalCountQuery",
     ],
   });
   if (dataImportDataset?.data?.importDataset?.error) {

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/import-images.ts
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/import-images.ts
@@ -11,7 +11,7 @@ import { DroppedFile, SetUploadStatuses } from "../../types";
 import { BATCH_SIZE, CONCURRENCY } from "../../constants";
 
 const CREATE_MANY_IMAGES_MUTATION = gql`
-  mutation createManyImagesInModal(
+  mutation CreateManyImagesInModalMutation(
     $images: [ImageCreateManySingleInput!]!
     $datasetId: ID!
   ) {

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/modal-dropzone.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/modal-dropzone.tsx
@@ -18,7 +18,7 @@ import { flushPaginatedImagesCache } from "../../../dataset-images-list";
 import { GET_DATASET_BY_SLUG_QUERY } from "../../../datasets/datasets.query";
 
 const GET_WORKSPACE_ID_QUERY = gql`
-  query getWorkspaceId($workspaceSlug: String) {
+  query GetWorkspaceIdQuery($workspaceSlug: String) {
     workspace(where: { slug: $workspaceSlug }) {
       id
     }

--- a/typescript/web/src/components/import-button/import-images-modal/modal-url-list/import-urls.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-url-list/import-urls.tsx
@@ -7,7 +7,7 @@ import { DroppedUrl, SetUploadStatuses } from "../types";
 import { BATCH_SIZE, CONCURRENCY } from "../constants";
 
 const CREATE_MANY_IMAGES_MUTATION = gql`
-  mutation createManyImages(
+  mutation CreateManyImagesMutation(
     $images: [ImageCreateManySingleInput!]!
     $datasetId: ID!
   ) {

--- a/typescript/web/src/components/invitation-manager/index.tsx
+++ b/typescript/web/src/components/invitation-manager/index.tsx
@@ -12,7 +12,7 @@ import { InvalidInvitation } from "./invalid-invitation";
 import { UserNeedsToSignIn } from "./user-needs-to-sign-in";
 
 const INVITATION_DETAILS_QUERY = gql`
-  query invitationDetails($id: ID!) {
+  query InvitationDetailsQuery($id: ID!) {
     membership(where: { id: $id }) {
       id
       currentUserCanAcceptInvitation
@@ -27,7 +27,7 @@ const INVITATION_DETAILS_QUERY = gql`
 `;
 
 const ACCEPT_INVITATION_MUTATION = gql`
-  mutation acceptInvitation($id: ID!) {
+  mutation AcceptInvitationMutation($id: ID!) {
     acceptInvitation(where: { id: $id }) {
       id
     }
@@ -35,7 +35,7 @@ const ACCEPT_INVITATION_MUTATION = gql`
 `;
 
 const DECLINE_INVITATION_MUTATION = gql`
-  mutation declineInvitation($id: ID!) {
+  mutation DeclineInvitationMutation($id: ID!) {
     declineInvitation(where: { id: $id }) {
       id
     }

--- a/typescript/web/src/components/labeling-tool/openlayers-map/iog/queries.ts
+++ b/typescript/web/src/components/labeling-tool/openlayers-map/iog/queries.ts
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client";
 
 export const IMAGE_QUERY = gql`
-  query getImage($id: ID!) {
+  query GetImageQuery($id: ID!) {
     image(where: { id: $id }) {
       id
       url
@@ -12,7 +12,7 @@ export const IMAGE_QUERY = gql`
 `;
 
 export const LABEL_QUERY = gql`
-  query getLabelIdSmartTool($id: ID!) {
+  query GetLabelIdSmartToolQuery($id: ID!) {
     label(where: { id: $id }) {
       id
       smartToolInput

--- a/typescript/web/src/components/labeling-tool/openlayers-map/openlayers-map.tsx
+++ b/typescript/web/src/components/labeling-tool/openlayers-map/openlayers-map.tsx
@@ -78,7 +78,7 @@ const getMemoizedProperties = memoize(
 );
 
 const IMAGE_QUERY = gql`
-  query image($id: ID!) {
+  query ImageQuery($id: ID!) {
     image(where: { id: $id }) {
       id
       width

--- a/typescript/web/src/components/labeling-tool/openlayers-map/queries.ts
+++ b/typescript/web/src/components/labeling-tool/openlayers-map/queries.ts
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client";
 
 export const GET_LABEL_CLASSES_OF_DATASET_QUERY = gql`
-  query getLabelClassesOfDataset($slug: String!, $workspaceSlug: String!) {
+  query GetLabelClassesOfDatasetQuery($slug: String!, $workspaceSlug: String!) {
     dataset(where: { slugs: { slug: $slug, workspaceSlug: $workspaceSlug } }) {
       id
       labelClasses {
@@ -14,7 +14,7 @@ export const GET_LABEL_CLASSES_OF_DATASET_QUERY = gql`
 `;
 
 export const GET_LABEL_QUERY = gql`
-  query getLabelWithLabelClass($id: ID!) {
+  query GetLabelWithLabelClassQuery($id: ID!) {
     label(where: { id: $id }) {
       id
       type
@@ -28,7 +28,7 @@ export const GET_LABEL_QUERY = gql`
 `;
 
 export const GET_IMAGE_LABELS_QUERY = gql`
-  query getImageLabels($imageId: ID!) {
+  query GetImageLabelsQuery($imageId: ID!) {
     image(where: { id: $imageId }) {
       id
       width
@@ -55,7 +55,7 @@ export const GET_IMAGE_LABELS_QUERY = gql`
 `;
 
 export const labelClassQuery = gql`
-  query getLabelClass($id: ID!) {
+  query GetLabelClassQuery($id: ID!) {
     labelClass(where: { id: $id }) {
       id
       name

--- a/typescript/web/src/components/labeling-tool/openlayers-map/select-and-modify-feature/index.tsx
+++ b/typescript/web/src/components/labeling-tool/openlayers-map/select-and-modify-feature/index.tsx
@@ -29,7 +29,7 @@ extend({
 });
 
 const GET_LABEL_QUERY = gql`
-  query getLabelWithGeometryAndClass($id: ID!) {
+  query GetLabelWithGeometryAndClassQuery($id: ID!) {
     label(where: { id: $id }) {
       type
       id

--- a/typescript/web/src/components/settings/workspace/danger-zone/delete-workspace.mutation.ts
+++ b/typescript/web/src/components/settings/workspace/danger-zone/delete-workspace.mutation.ts
@@ -6,7 +6,7 @@ import { useApolloErrorToast } from "../../../toast";
 import { useWorkspaceSettings } from "../context";
 
 const DELETE_WORKSPACE_MUTATION = gql`
-  mutation deleteWorkspace($slug: String!) {
+  mutation DeleteWorkspaceMutation($slug: String!) {
     deleteWorkspace(where: { slug: $slug }) {
       deletedAt
     }

--- a/typescript/web/src/components/settings/workspace/profile.tsx
+++ b/typescript/web/src/components/settings/workspace/profile.tsx
@@ -29,7 +29,7 @@ import { useWorkspaceSettings } from "./context";
 const TeamIcon = chakra(RiGroupFill);
 
 const UPDATE_WORKSPACE_MUTATION = gql`
-  mutation updateWorkspace(
+  mutation UpdateWorkspaceMutation(
     $workspaceSlug: String
     $name: String
     $image: String
@@ -59,7 +59,7 @@ const useUpdateWorkspace = (): [() => void, string | undefined] => {
       image: null,
       workspaceSlug: workspace?.slug,
     },
-    refetchQueries: ["getWorkspaces"],
+    refetchQueries: ["GetWorkspacesQuery"],
     onCompleted: (data) => {
       if (!data?.updateWorkspace) return;
       router.push(`/${data.updateWorkspace.slug}/settings`);

--- a/typescript/web/src/components/welcome-manager/welcome-modal.tsx
+++ b/typescript/web/src/components/welcome-manager/welcome-modal.tsx
@@ -26,7 +26,7 @@ type WelcomeModalParam =
   | "closed"; // Force it to be closed and never open
 
 export const GET_DATASETS_QUERY = gql`
-  query getDatasetsName($where: DatasetWhereInput) {
+  query GetDatasetsNameQuery($where: DatasetWhereInput) {
     datasets(where: $where) {
       id
       name
@@ -35,7 +35,7 @@ export const GET_DATASETS_QUERY = gql`
 `;
 
 export const CREATE_DEMO_DATASET_QUERY = gql`
-  mutation createDemoDataset {
+  mutation CreateDemoDatasetMutation {
     createDemoDataset {
       id
       name
@@ -91,16 +91,16 @@ const performWelcomeWorkflow = async ({
         await client.mutate({
           mutation: CREATE_DEMO_DATASET_QUERY,
           refetchQueries: [
-            "getDatasetData",
-            "getDatasetName",
-            "getDatasetsNames",
-            "getDatasetById",
-            "getAllImagesOfADataset",
-            "getDataset",
-            "countLabelsOfDataset",
-            "getLabelClassesOfDataset",
-            "image",
-            "getImageLabels",
+            "GetDatasetDataQuery",
+            "GetDatasetNameQuery",
+            "GetDatasetsNamesQuery",
+            "GetDatasetByIdQuery",
+            "GetAllImagesOfADatasetQuery",
+            "GetDatasetQuery",
+            "CountLabelsOfDatasetQuery",
+            "GetLabelClassesOfDatasetQuery",
+            "ImageQuery",
+            "GetImageLabelsQuery",
           ],
         });
       if (createDemoDatasetErrors) {

--- a/typescript/web/src/components/workspace-name-input/workspace-exists.query.ts
+++ b/typescript/web/src/components/workspace-name-input/workspace-exists.query.ts
@@ -2,7 +2,7 @@ import { gql, QueryHookOptions, QueryResult, useQuery } from "@apollo/client";
 import { Query, QueryWorkspaceExistsArgs } from "@labelflow/graphql-types";
 
 export const WORKSPACE_EXISTS_QUERY = gql`
-  query workspaceExists($slug: String!) {
+  query WorkspaceExistsQuery($slug: String!) {
     workspaceExists(where: { slug: $slug })
   }
 `;

--- a/typescript/web/src/components/workspace-switcher/create-workspace-modal/create-workspace.mutation.ts
+++ b/typescript/web/src/components/workspace-switcher/create-workspace-modal/create-workspace.mutation.ts
@@ -21,7 +21,7 @@ import { useQueryParam } from "use-query-params";
 import { BoolParam } from "../../../utils/query-param-bool";
 
 export const CREATE_WORKSPACE_MUTATION = gql`
-  mutation createWorkspace($name: String!) {
+  mutation CreateWorkspaceMutation($name: String!) {
     createWorkspace(data: { name: $name }) {
       id
       slug
@@ -103,7 +103,7 @@ export function useCreateWorkspaceMutation(
     CREATE_WORKSPACE_MUTATION,
     {
       variables: { name: workspaceName },
-      refetchQueries: ["getWorkspaces"],
+      refetchQueries: ["GetWorkspacesQuery"],
       onCompleted,
       onError,
     }

--- a/typescript/web/src/components/workspace-switcher/workspace-switcher.tsx
+++ b/typescript/web/src/components/workspace-switcher/workspace-switcher.tsx
@@ -9,7 +9,7 @@ import { WorkspaceMenu } from "./workspace-menu";
 import { WorkspaceItem } from "./workspace-menu/workspace-selection-popover";
 
 const GET_WORKSPACES_QUERY = gql`
-  query getWorkspaces {
+  query GetWorkspacesQuery {
     workspaces {
       id
       name

--- a/typescript/web/src/connectors/undo-store/effects/create-iog-label.ts
+++ b/typescript/web/src/connectors/undo-store/effects/create-iog-label.ts
@@ -8,7 +8,7 @@ import { deleteLabelMutationUpdate } from "./cache-updates/delete-label-mutation
 import { DELETE_LABEL_MUTATION } from "./shared-queries";
 
 const CREATE_IOG_LABEL_MUTATION = gql`
-  mutation createIogLabel(
+  mutation CreateIogLabelMutation(
     $id: ID!
     $imageId: String!
     $x: Float!
@@ -95,7 +95,7 @@ export const createCreateIogLabelEffect = (
         centerPoint,
         labelClassId,
       },
-      refetchQueries: ["countLabelsOfDataset", "getImageLabels"],
+      refetchQueries: ["CountLabelsOfDatasetQuery", "GetImageLabelsQuery"],
       optimisticResponse: {
         createIogLabel: { id, __typename: "Label" },
       },
@@ -115,7 +115,7 @@ export const createCreateIogLabelEffect = (
     await client.mutate({
       mutation: DELETE_LABEL_MUTATION,
       variables: { id: labelId },
-      refetchQueries: ["countLabelsOfDataset"],
+      refetchQueries: ["CountLabelsOfDatasetQuery"],
       optimisticResponse: { deleteLabel: { id: labelId, __typename: "Label" } },
       update: deleteLabelMutationUpdate({ imageId, id: labelId, labelClassId }),
     });

--- a/typescript/web/src/connectors/undo-store/effects/create-label-class-and-create-label.ts
+++ b/typescript/web/src/connectors/undo-store/effects/create-label-class-and-create-label.ts
@@ -15,7 +15,7 @@ import {
   CREATE_LABEL_CLASS_QUERY,
   CREATE_LABEL_MUTATION,
   DELETE_LABEL_MUTATION,
-  DELETE_LABEL_CLASS_QUERY,
+  DELETE_LABEL_CLASS_MUTATION,
 } from "./shared-queries";
 
 export const createCreateLabelClassAndCreateLabelEffect = (
@@ -115,7 +115,7 @@ export const createCreateLabelClassAndCreateLabelEffect = (
     setSelectedLabelId(null);
 
     await client.mutate({
-      mutation: DELETE_LABEL_CLASS_QUERY,
+      mutation: DELETE_LABEL_CLASS_MUTATION,
       variables: {
         where: { id: labelClassId },
       },

--- a/typescript/web/src/connectors/undo-store/effects/create-label-class-and-create-label.ts
+++ b/typescript/web/src/connectors/undo-store/effects/create-label-class-and-create-label.ts
@@ -72,7 +72,7 @@ export const createCreateLabelClassAndCreateLabelEffect = (
     const { data } = await client.mutate({
       mutation: CREATE_LABEL_MUTATION,
       variables: { data: createLabelInputs },
-      refetchQueries: ["countLabelsOfDataset"],
+      refetchQueries: ["CountLabelsOfDatasetQuery"],
       optimisticResponse: {
         createLabel: { id: `temp-${Date.now()}`, __typename: "Label" },
       },
@@ -103,7 +103,7 @@ export const createCreateLabelClassAndCreateLabelEffect = (
     await client.mutate({
       mutation: DELETE_LABEL_MUTATION,
       variables: { id },
-      refetchQueries: ["countLabelsOfDataset"],
+      refetchQueries: ["CountLabelsOfDatasetQuery"],
       optimisticResponse: { deleteLabel: { id, __typename: "Label" } },
       update: deleteLabelMutationUpdate({
         id,
@@ -165,7 +165,7 @@ export const createCreateLabelClassAndCreateLabelEffect = (
     const { data } = await client.mutate({
       mutation: CREATE_LABEL_MUTATION,
       variables: { data: createLabelInputs },
-      refetchQueries: ["countLabelsOfDataset"],
+      refetchQueries: ["CountLabelsOfDatasetQuery"],
       optimisticResponse: {
         createLabel: { id: `temp-${Date.now()}`, __typename: "Label" },
       },

--- a/typescript/web/src/connectors/undo-store/effects/create-label-class-and-update-label.ts
+++ b/typescript/web/src/connectors/undo-store/effects/create-label-class-and-update-label.ts
@@ -10,7 +10,7 @@ import {
   GET_LABEL_QUERY,
   CREATE_LABEL_CLASS_QUERY,
   UPDATE_LABEL_MUTATION,
-  DELETE_LABEL_CLASS_QUERY,
+  DELETE_LABEL_CLASS_MUTATION,
 } from "./shared-queries";
 import { updateLabelClassOfLabel } from "./cache-updates/update-label-class-of-label";
 
@@ -135,7 +135,7 @@ export const createCreateLabelClassAndUpdateLabelEffect = (
     useLabelingStore.setState({ selectedLabelClassId: labelClassIdPrevious });
 
     await client.mutate({
-      mutation: DELETE_LABEL_CLASS_QUERY,
+      mutation: DELETE_LABEL_CLASS_MUTATION,
       variables: {
         where: { id: labelClassId },
       },

--- a/typescript/web/src/connectors/undo-store/effects/create-label-class.ts
+++ b/typescript/web/src/connectors/undo-store/effects/create-label-class.ts
@@ -9,7 +9,7 @@ import { createLabelClassMutationUpdate } from "./cache-updates/create-label-cla
 import { deleteLabelClassMutationUpdate } from "./cache-updates/delete-label-class-mutation-update";
 import {
   CREATE_LABEL_CLASS_QUERY,
-  DELETE_LABEL_CLASS_QUERY,
+  DELETE_LABEL_CLASS_MUTATION,
 } from "./shared-queries";
 
 export const createCreateLabelClassEffect = (
@@ -50,7 +50,7 @@ export const createCreateLabelClassEffect = (
   },
   undo: async (labelClassId: string) => {
     await client.mutate({
-      mutation: DELETE_LABEL_CLASS_QUERY,
+      mutation: DELETE_LABEL_CLASS_MUTATION,
       variables: {
         where: { id: labelClassId },
       },

--- a/typescript/web/src/connectors/undo-store/effects/create-label.ts
+++ b/typescript/web/src/connectors/undo-store/effects/create-label.ts
@@ -40,7 +40,7 @@ export const createCreateLabelEffect = (
     const createLabelPromise = client.mutate({
       mutation: CREATE_LABEL_MUTATION,
       variables: { data: createLabelInputs },
-      refetchQueries: ["countLabelsOfDataset"],
+      refetchQueries: ["CountLabelsOfDatasetQuery"],
       optimisticResponse: {
         createLabel: { id, __typename: "Label" },
       },
@@ -61,7 +61,7 @@ export const createCreateLabelEffect = (
     await client.mutate({
       mutation: DELETE_LABEL_MUTATION,
       variables: { id },
-      refetchQueries: ["countLabelsOfDataset"],
+      refetchQueries: ["CountLabelsOfDatasetQuery"],
       optimisticResponse: { deleteLabel: { id, __typename: "Label" } },
       update: deleteLabelMutationUpdate({
         id,

--- a/typescript/web/src/connectors/undo-store/effects/delete-label.ts
+++ b/typescript/web/src/connectors/undo-store/effects/delete-label.ts
@@ -8,7 +8,7 @@ import { deleteLabelMutationUpdate } from "./cache-updates/delete-label-mutation
 import { CREATE_LABEL_MUTATION } from "./shared-queries";
 
 const DELETE_LABEL_MUTATION = gql`
-  mutation deleteLabelInUndoStore($id: ID!) {
+  mutation DeleteLabelInUndoStoreMutation($id: ID!) {
     deleteLabel(where: { id: $id }) {
       id
       x
@@ -44,7 +44,7 @@ export const createDeleteLabelEffect = (
     }>({
       mutation: DELETE_LABEL_MUTATION,
       variables: { id },
-      refetchQueries: ["countLabelsOfDataset"],
+      refetchQueries: ["CountLabelsOfDatasetQuery"],
       /* Note that there is no optimistic response here, only a cache update.
        * We could add it but it would imply to fetch a lot of data beforehand */
       update: deleteLabelMutationUpdate(),
@@ -82,7 +82,7 @@ export const createDeleteLabelEffect = (
     await client.mutate({
       mutation: CREATE_LABEL_MUTATION,
       variables: { data: createLabelInputs },
-      refetchQueries: ["countLabelsOfDataset"],
+      refetchQueries: ["CountLabelsOfDatasetQuery"],
       optimisticResponse: { createLabel: { id, __typename: "Label" } },
       update: createLabelMutationUpdate(createLabelInputs),
     });

--- a/typescript/web/src/connectors/undo-store/effects/shared-queries/index.ts
+++ b/typescript/web/src/connectors/undo-store/effects/shared-queries/index.ts
@@ -15,7 +15,7 @@ import { gql } from "@apollo/client";
 /* ----------------------------------------------------------------- */
 
 export const IMAGE_DIMENSIONS_QUERY = gql`
-  query imageDimensions($id: ID!) {
+  query ImageDimensionsQuery($id: ID!) {
     image(where: { id: $id }) {
       id
       width
@@ -44,7 +44,7 @@ export const CREATED_LABEL_FRAGMENT = gql`
 `;
 
 export const CREATE_LABEL_CLASS_QUERY = gql`
-  mutation createLabelClassInEffects($data: LabelClassCreateInput!) {
+  mutation CreateLabelClassInEffectsQuery($data: LabelClassCreateInput!) {
     createLabelClass(data: $data) {
       id
       name
@@ -54,7 +54,7 @@ export const CREATE_LABEL_CLASS_QUERY = gql`
 `;
 
 export const DELETE_LABEL_CLASS_QUERY = gql`
-  mutation deleteLabelClass($where: LabelClassWhereUniqueInput!) {
+  mutation DeleteLabelClassMutation($where: LabelClassWhereUniqueInput!) {
     deleteLabelClass(where: $where) {
       id
     }
@@ -62,7 +62,7 @@ export const DELETE_LABEL_CLASS_QUERY = gql`
 `;
 
 export const CREATE_LABEL_MUTATION = gql`
-  mutation createLabel($data: LabelCreateInput!) {
+  mutation CreateLabelMutation($data: LabelCreateInput!) {
     createLabel(data: $data) {
       id
     }
@@ -70,7 +70,7 @@ export const CREATE_LABEL_MUTATION = gql`
 `;
 
 export const DELETE_LABEL_MUTATION = gql`
-  mutation deleteLabel($id: ID!) {
+  mutation DeleteLabelMutation($id: ID!) {
     deleteLabel(where: { id: $id }) {
       id
     }
@@ -78,7 +78,7 @@ export const DELETE_LABEL_MUTATION = gql`
 `;
 
 export const GET_LABEL_QUERY = gql`
-  query getLabelIdAndClassId($id: ID!) {
+  query GetLabelIdAndClassIdQuery($id: ID!) {
     label(where: { id: $id }) {
       id
       labelClass {
@@ -89,7 +89,7 @@ export const GET_LABEL_QUERY = gql`
 `;
 
 export const UPDATE_LABEL_MUTATION = gql`
-  mutation updateLabelClass(
+  mutation UpdateLabelClassMutation(
     $where: LabelWhereUniqueInput!
     $data: LabelUpdateInput!
   ) {

--- a/typescript/web/src/connectors/undo-store/effects/shared-queries/index.ts
+++ b/typescript/web/src/connectors/undo-store/effects/shared-queries/index.ts
@@ -44,7 +44,7 @@ export const CREATED_LABEL_FRAGMENT = gql`
 `;
 
 export const CREATE_LABEL_CLASS_QUERY = gql`
-  mutation CreateLabelClassInEffectsQuery($data: LabelClassCreateInput!) {
+  mutation CreateLabelClassActionMutation($data: LabelClassCreateInput!) {
     createLabelClass(data: $data) {
       id
       name
@@ -53,8 +53,8 @@ export const CREATE_LABEL_CLASS_QUERY = gql`
   }
 `;
 
-export const DELETE_LABEL_CLASS_QUERY = gql`
-  mutation DeleteLabelClassMutation($where: LabelClassWhereUniqueInput!) {
+export const DELETE_LABEL_CLASS_MUTATION = gql`
+  mutation DeleteLabelClassActionMutation($where: LabelClassWhereUniqueInput!) {
     deleteLabelClass(where: $where) {
       id
     }
@@ -62,7 +62,7 @@ export const DELETE_LABEL_CLASS_QUERY = gql`
 `;
 
 export const CREATE_LABEL_MUTATION = gql`
-  mutation CreateLabelMutation($data: LabelCreateInput!) {
+  mutation CreateLabelActionMutation($data: LabelCreateInput!) {
     createLabel(data: $data) {
       id
     }
@@ -70,7 +70,7 @@ export const CREATE_LABEL_MUTATION = gql`
 `;
 
 export const DELETE_LABEL_MUTATION = gql`
-  mutation DeleteLabelMutation($id: ID!) {
+  mutation DeleteLabelActionMutation($id: ID!) {
     deleteLabel(where: { id: $id }) {
       id
     }
@@ -89,7 +89,7 @@ export const GET_LABEL_QUERY = gql`
 `;
 
 export const UPDATE_LABEL_MUTATION = gql`
-  mutation UpdateLabelClassMutation(
+  mutation UpdateLabelClassActionMutation(
     $where: LabelWhereUniqueInput!
     $data: LabelUpdateInput!
   ) {

--- a/typescript/web/src/connectors/undo-store/effects/update-iog-label.ts
+++ b/typescript/web/src/connectors/undo-store/effects/update-iog-label.ts
@@ -5,7 +5,7 @@ import { Label } from "@labelflow/graphql-types";
 import { Effect } from "..";
 
 const UPDATE_LABEL_MUTATION = gql`
-  mutation UpdateLabelMutation(
+  mutation UndoUpdateIogLabelMutation(
     $id: ID!
     $geometry: GeometryInput
     $smartToolInput: JSON

--- a/typescript/web/src/connectors/undo-store/effects/update-iog-label.ts
+++ b/typescript/web/src/connectors/undo-store/effects/update-iog-label.ts
@@ -5,7 +5,7 @@ import { Label } from "@labelflow/graphql-types";
 import { Effect } from "..";
 
 const UPDATE_LABEL_MUTATION = gql`
-  mutation updateLabel(
+  mutation UpdateLabelMutation(
     $id: ID!
     $geometry: GeometryInput
     $smartToolInput: JSON
@@ -29,7 +29,7 @@ const UPDATE_LABEL_MUTATION = gql`
 `;
 
 const GET_LABEL_QUERY = gql`
-  query getLabelGeometryAndSmartTool($id: ID!) {
+  query GetLabelGeometryAndSmartToolQuery($id: ID!) {
     label(where: { id: $id }) {
       id
       x
@@ -46,7 +46,7 @@ const GET_LABEL_QUERY = gql`
 `;
 
 const updateIogLabelMutation = gql`
-  mutation updateIogLabel(
+  mutation UpdateIogLabelMutation(
     $id: ID!
     $x: Float
     $y: Float

--- a/typescript/web/src/connectors/undo-store/effects/update-label-class-of-label.ts
+++ b/typescript/web/src/connectors/undo-store/effects/update-label-class-of-label.ts
@@ -7,7 +7,7 @@ import { updateLabelClassOfLabel } from "./cache-updates/update-label-class-of-l
 import { GET_LABEL_QUERY } from "./shared-queries";
 
 const UPDATE_LABEL_MUTATION = gql`
-  mutation updateLabelClassOfLabel(
+  mutation UpdateLabelClassOfLabelMutation(
     $where: LabelWhereUniqueInput!
     $data: LabelUpdateInput!
   ) {

--- a/typescript/web/src/connectors/undo-store/effects/update-label.ts
+++ b/typescript/web/src/connectors/undo-store/effects/update-label.ts
@@ -2,6 +2,7 @@ import { ApolloClient, gql } from "@apollo/client";
 import { GeometryInput, Label } from "@labelflow/graphql-types";
 import { getBoundedGeometryFromImage } from "@labelflow/common-resolvers";
 import { Effect } from "..";
+import { IMAGE_DIMENSIONS_QUERY } from "./shared-queries";
 
 const UPDATE_LABEL_MUTATION = gql`
   mutation UpdateLabelMutation(
@@ -26,16 +27,6 @@ const UPDATE_LABEL_MUTATION = gql`
       labelClass {
         id
       }
-    }
-  }
-`;
-
-const IMAGE_DIMENSIONS_QUERY = gql`
-  query ImageDimensionsQuery($id: ID!) {
-    image(where: { id: $id }) {
-      id
-      width
-      height
     }
   }
 `;

--- a/typescript/web/src/connectors/undo-store/effects/update-label.ts
+++ b/typescript/web/src/connectors/undo-store/effects/update-label.ts
@@ -4,7 +4,11 @@ import { getBoundedGeometryFromImage } from "@labelflow/common-resolvers";
 import { Effect } from "..";
 
 const UPDATE_LABEL_MUTATION = gql`
-  mutation updateLabel($id: ID!, $geometry: GeometryInput, $labelClassId: ID) {
+  mutation UpdateLabelMutation(
+    $id: ID!
+    $geometry: GeometryInput
+    $labelClassId: ID
+  ) {
     updateLabel(
       where: { id: $id }
       data: { geometry: $geometry, labelClassId: $labelClassId }
@@ -27,7 +31,7 @@ const UPDATE_LABEL_MUTATION = gql`
 `;
 
 const IMAGE_DIMENSIONS_QUERY = gql`
-  query imageDimensions($id: ID!) {
+  query ImageDimensionsQuery($id: ID!) {
     image(where: { id: $id }) {
       id
       width
@@ -37,7 +41,7 @@ const IMAGE_DIMENSIONS_QUERY = gql`
 `;
 
 const GET_LABEL_QUERY = gql`
-  query getLabelAndGeometry($id: ID!) {
+  query GetLabelAndGeometryQuery($id: ID!) {
     label(where: { id: $id }) {
       id
       type

--- a/typescript/web/src/hooks/use-image-pre-fetching.ts
+++ b/typescript/web/src/hooks/use-image-pre-fetching.ts
@@ -3,7 +3,7 @@ import { useEffect, useReducer } from "react";
 import { useImagesNavigation } from "./use-images-navigation";
 
 const IMAGE_QUERY = gql`
-  query prefetchImage($id: ID!) {
+  query PrefetchImageQuery($id: ID!) {
     image(where: { id: $id }) {
       id
       width
@@ -15,7 +15,7 @@ const IMAGE_QUERY = gql`
 `;
 
 const GET_IMAGE_LABELS_QUERY = gql`
-  query getImageLabelsForPrefetch($imageId: ID!) {
+  query GetImageLabelsForPrefetchQuery($imageId: ID!) {
     image(where: { id: $imageId }) {
       id
       width

--- a/typescript/web/src/hooks/use-images-navigation.ts
+++ b/typescript/web/src/hooks/use-images-navigation.ts
@@ -4,7 +4,7 @@ import { useQuery, gql } from "@apollo/client";
 import { Dataset, Image } from "@labelflow/graphql-types";
 
 const GET_ALL_IMAGES_OF_A_DATASET_QUERY = gql`
-  query getAllImagesOfADataset($slug: String!, $workspaceSlug: String!) {
+  query GetAllImagesOfADatasetQuery($slug: String!, $workspaceSlug: String!) {
     dataset(where: { slugs: { slug: $slug, workspaceSlug: $workspaceSlug } }) {
       id
       images {

--- a/typescript/web/src/pages/[workspaceSlug]/datasets/[datasetSlug]/classes/index.tsx
+++ b/typescript/web/src/pages/[workspaceSlug]/datasets/[datasetSlug]/classes/index.tsx
@@ -21,7 +21,7 @@ import { WorkspaceSwitcher } from "../../../../../components/workspace-switcher"
 import { Error404Content } from "../../../../404";
 
 const DATASET_NAME_QUERY = gql`
-  query getDatasetName($slug: String!, $workspaceSlug: String!) {
+  query GetDatasetNameQuery($slug: String!, $workspaceSlug: String!) {
     dataset(where: { slugs: { slug: $slug, workspaceSlug: $workspaceSlug } }) {
       id
       name

--- a/typescript/web/src/pages/[workspaceSlug]/datasets/[datasetSlug]/images/[imageId].tsx
+++ b/typescript/web/src/pages/[workspaceSlug]/datasets/[datasetSlug]/images/[imageId].tsx
@@ -43,7 +43,7 @@ const LabelingTool = dynamic(
 );
 
 const IMAGE_QUERY = gql`
-  query imageName($id: ID!) {
+  query ImageNameQuery($id: ID!) {
     image(where: { id: $id }) {
       id
       name

--- a/typescript/web/src/pages/[workspaceSlug]/datasets/[datasetSlug]/images/index.tsx
+++ b/typescript/web/src/pages/[workspaceSlug]/datasets/[datasetSlug]/images/index.tsx
@@ -21,7 +21,7 @@ import { CookieBanner } from "../../../../../components/cookie-banner";
 import { ImagesList } from "../../../../../components/dataset-images-list";
 
 export const DATASET_DATA_QUERY = gql`
-  query getDatasetData($slug: String!, $workspaceSlug: String!) {
+  query GetDatasetDataQuery($slug: String!, $workspaceSlug: String!) {
     dataset(where: { slugs: { slug: $slug, workspaceSlug: $workspaceSlug } }) {
       id
       name

--- a/typescript/web/src/pages/[workspaceSlug]/members/index.tsx
+++ b/typescript/web/src/pages/[workspaceSlug]/members/index.tsx
@@ -13,7 +13,7 @@ import { WelcomeModal } from "../../../components/welcome-manager";
 import { WorkspaceSwitcher } from "../../../components/workspace-switcher";
 
 const MEMBERSHIPS_QUERY = gql`
-  query getMembershipsMembers($workspaceSlug: String) {
+  query GetMembershipsMembersQuery($workspaceSlug: String) {
     memberships(where: { workspaceSlug: $workspaceSlug }) {
       id
       role
@@ -35,7 +35,7 @@ const MEMBERSHIPS_QUERY = gql`
 `;
 
 const DELETE_MEMBERSHIP_MUTATION = gql`
-  mutation deleteMembership($id: ID!) {
+  mutation DeleteMembershipMutation($id: ID!) {
     deleteMembership(where: { id: $id }) {
       id
     }
@@ -43,7 +43,7 @@ const DELETE_MEMBERSHIP_MUTATION = gql`
 `;
 
 const UPDATE_MEMBERSHIP_MUTATION = gql`
-  mutation updateMembership($id: ID!, $data: MembershipUpdateInput!) {
+  mutation UpdateMembershipMutation($id: ID!, $data: MembershipUpdateInput!) {
     updateMembership(where: { id: $id }, data: $data) {
       id
     }
@@ -51,7 +51,7 @@ const UPDATE_MEMBERSHIP_MUTATION = gql`
 `;
 
 const INVITE_MEMBER_MUTATION = gql`
-  mutation inviteMember($where: InviteMemberInput!) {
+  mutation InviteMemberMutation($where: InviteMemberInput!) {
     inviteMember(where: $where)
   }
 `;
@@ -65,15 +65,15 @@ const WorkspaceMembersPage = () => {
   });
 
   const [deleteMembership] = useMutation(DELETE_MEMBERSHIP_MUTATION, {
-    refetchQueries: ["getMembershipsMembers"],
+    refetchQueries: ["GetMembershipsMembersQuery"],
   });
 
   const [updateMembership] = useMutation(UPDATE_MEMBERSHIP_MUTATION, {
-    refetchQueries: ["getMembershipsMembers"],
+    refetchQueries: ["GetMembershipsMembersQuery"],
   });
 
   const [inviteMember] = useMutation(INVITE_MEMBER_MUTATION, {
-    refetchQueries: ["getMembershipsMembers"],
+    refetchQueries: ["GetMembershipsMembersQuery"],
   });
 
   return (

--- a/typescript/web/src/pages/[workspaceSlug]/settings/index.tsx
+++ b/typescript/web/src/pages/[workspaceSlug]/settings/index.tsx
@@ -15,7 +15,7 @@ import { WelcomeModal } from "../../../components/welcome-manager";
 import { WorkspaceSwitcher } from "../../../components/workspace-switcher";
 
 const GET_WORKSPACE_DETAILS_QUERY = gql`
-  query getWorkspaceDetails($workspaceSlug: String) {
+  query GetWorkspaceDetailsQuery($workspaceSlug: String) {
     workspace(where: { slug: $workspaceSlug }) {
       id
       plan

--- a/typescript/web/src/pages/debug.tsx
+++ b/typescript/web/src/pages/debug.tsx
@@ -27,7 +27,7 @@ import { CookieBanner } from "../components/cookie-banner";
 import { NavLogo } from "../components/logo/nav-logo";
 
 export const DEBUG_QUERY = gql`
-  query getDebug {
+  query GetDebugQuery {
     debug
   }
 `;

--- a/typescript/web/src/pages/settings/profile/index.tsx
+++ b/typescript/web/src/pages/settings/profile/index.tsx
@@ -10,8 +10,8 @@ import { NavLogo } from "../../../components/logo/nav-logo";
 import { UserSettings } from "../../../components/settings/user";
 import { USER_QUERY } from "../../../utils/shared-queries";
 
-const UPDATE_USER_QUERY = gql`
-  mutation updateUser($id: ID!, $data: UserUpdateInput!) {
+const UPDATE_USER_MUTATION = gql`
+  mutation UpdateUserMutation($id: ID!, $data: UserUpdateInput!) {
     updateUser(where: { id: $id }, data: $data) {
       id
     }
@@ -27,8 +27,8 @@ const ProfilePage = () => {
     skip: userInfoFromSession?.id == null,
   });
   const user = userData?.user;
-  const [updateUser] = useMutation(UPDATE_USER_QUERY, {
-    refetchQueries: ["getUserProfileInfo"],
+  const [updateUser] = useMutation(UPDATE_USER_MUTATION, {
+    refetchQueries: ["GetUserProfileInfoQuery"],
   });
   const changeUserName = useCallback(
     (name: string) => {

--- a/typescript/web/src/utils/mock-image-loader.tsx
+++ b/typescript/web/src/utils/mock-image-loader.tsx
@@ -34,7 +34,7 @@ async function createImage(
   try {
     const mutationResult = await client.mutate({
       mutation: gql`
-        mutation createImageInMock(
+        mutation CreateImageInMockMutations(
           $url: String!
           $id: ID
           $name: String!

--- a/typescript/web/src/utils/shared-queries/index.ts
+++ b/typescript/web/src/utils/shared-queries/index.ts
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client";
 
 export const USER_QUERY = gql`
-  query getUserProfileInfo($id: ID!) {
+  query GetUserProfileInfoQuery($id: ID!) {
     user(where: { id: $id }) {
       id
       createdAt
@@ -13,7 +13,7 @@ export const USER_QUERY = gql`
 `;
 
 export const GET_DATASETS_QUERY = gql`
-  query getDatasets($where: DatasetWhereInput) {
+  query GetDatasetsQuery($where: DatasetWhereInput) {
     datasets(where: $where) {
       id
       name

--- a/typescript/web/src/utils/tests/mutations.ts
+++ b/typescript/web/src/utils/tests/mutations.ts
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client";
 
 export const CREATE_TEST_DATASET_MUTATION = gql`
-  mutation createTestDataset(
+  mutation CreateTestDatasetMutation(
     $datasetId: ID
     $name: String!
     $workspaceSlug: String!
@@ -17,7 +17,7 @@ export const CREATE_TEST_DATASET_MUTATION = gql`
 `;
 
 export const CREATE_TEST_IMAGE_MUTATION = gql`
-  mutation createImageForTests(
+  mutation CreateImageForTestsMutation(
     $url: String
     $id: ID
     $name: String
@@ -50,7 +50,7 @@ export const CREATE_TEST_IMAGE_MUTATION = gql`
 `;
 
 export const CREATE_LOCAL_TEST_DATASET_MUTATION = gql`
-  mutation createLocalTestDataset {
+  mutation CreateLocalTestDatasetMutation {
     createDataset(data: { name: "Toto", workspaceSlug: "local" }) {
       id
     }

--- a/typescript/web/src/utils/upload-file.ts
+++ b/typescript/web/src/utils/upload-file.ts
@@ -3,7 +3,7 @@ import { ApolloClient, gql } from "@apollo/client";
 import { UploadTarget } from "@labelflow/graphql-types";
 
 const GET_IMAGE_UPLOAD_TARGET_MUTATION = gql`
-  mutation getUploadTarget($key: String!) {
+  mutation GetUploadTargetMutation($key: String!) {
     getUploadTarget(data: { key: $key }) {
       ... on UploadTargetDirect {
         direct


### PR DESCRIPTION
## Work performed

As the generated types were incorrectly named, I've followed the official Apollo way of naming client-side queries and mutations.

## Results

Generated types now have PascalCase. As usual with TypeScript types.
<!--- Does this pull-request fully implement the new feature? If not why? Create and link new issues. -->

## Problems encountered

<!--- Explain problems that were encountered when implementing this pull-request -->
I had to make sure that `refetchQueries` based on string names instead of object references were up-to-date.

## Caveats

<!--- Any particular attention point with what you did? -->
No

## Resolved issues

<!--- List references to issues that this PR resolves -->

Generated client-side types were named with camelCase

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
No