### PR TITLE
Only build the working Storybook files until the service worker is fully dropped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{secrets.ACTIONS_CACHE_VERSION}}-${{ hashFiles('yarn.lock') }}
+      - name: Generate code
+        run: yarn codegen
       - name: Lint project code
         run: yarn lint:ts
 
@@ -156,6 +158,8 @@ jobs:
         run: cd typescript/db && yarn deploy && yarn generate
         env:
           POSTGRES_EXTERNAL_URL: postgresql://admin:admin@localhost:5433/labelflow?schema=public
+      - name: Generate code
+        run: yarn codegen
       - name: run tests
         run: yarn test
         env:
@@ -174,7 +178,7 @@ jobs:
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{secrets.ACTIONS_CACHE_VERSION}}-${{ hashFiles('yarn.lock') }}
-      - name: run codegen:ci script
+      - name: Generate code and check for uncommitted changes
         run: yarn codegen:ci
       - name: Check for failure
         if: ${{ failure() }}
@@ -287,6 +291,8 @@ jobs:
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{secrets.ACTIONS_CACHE_VERSION}}-${{ hashFiles('yarn.lock') }}
+      - name: Generate code
+        run: yarn codegen
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         # Chromatic GitHub Action options
@@ -393,6 +399,8 @@ jobs:
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{secrets.ACTIONS_CACHE_VERSION}}-${{ hashFiles('yarn.lock') }}
+      - name: Generate code
+        run: yarn codegen
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         # Chromatic GitHub Action options

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,29 +1,66 @@
-const NodePolyfillPlugin = require("node-polyfill-webpack-plugin")
+const NodePolyfillPlugin = require("node-polyfill-webpack-plugin");
+
+// FIXME SW Delete this constant once every story has been fixed following the service worker removal
+const STORIES = [
+  "../typescript/react-openlayers-fiber/src/**/__stories__/*.tsx",
+  "../typescript/web/src/components/invitation-manager/__stories__/*.tsx",
+  "../typescript/web/src/components/optional-text/__stories__/*.tsx",
+  "../typescript/web/src/components/export-button/export-modal/__stories__/*.tsx",
+  "../typescript/web/src/components/export-button/__stories__/*.tsx",
+  "../typescript/web/src/components/datasets/__stories__/*.tsx",
+  "../typescript/web/src/components/class-selection-popover/class-list-item/__stories__/*.tsx",
+  "../typescript/web/src/components/class-selection-popover/__stories__/*.tsx",
+  "../typescript/web/src/components/layout/top-bar/keymap-button/keymap-modal/__stories__/*.tsx",
+  "../typescript/web/src/components/layout/top-bar/breadcrumbs/__stories__/*.tsx",
+  "../typescript/web/src/components/layout/tab-bar/__stories__/*.tsx",
+  // "../typescript/web/src/components/gallery/__stories__/*.tsx",
+  "../typescript/web/src/components/welcome-manager/__stories__/*.tsx",
+  "../typescript/web/src/components/cookie-banner/__stories__/*.tsx",
+  "../typescript/web/src/components/auth-manager/signin-modal/__stories__/*.tsx",
+  "../typescript/web/src/components/empty-state/__stories__/*.tsx",
+  "../typescript/web/src/components/members/__stories__/*.tsx",
+  "../typescript/web/src/components/reorderable-table/__stories__/*.tsx",
+  "../typescript/web/src/components/workspace-name-input/__stories__/*.tsx",
+  // "../typescript/web/src/components/labeling-tool/image-navigation/__stories__/*.tsx",
+  "../typescript/web/src/components/labeling-tool/options-tool-bar/class-addition-menu/__stories__/*.tsx",
+  "../typescript/web/src/components/labeling-tool/options-tool-bar/class-selection-menu/__stories__/*.tsx",
+  // "../typescript/web/src/components/labeling-tool/__stories__/*.tsx",
+  "../typescript/web/src/components/labeling-tool/drawing-tool-bar/__stories__/*.tsx",
+  "../typescript/web/src/components/import-button/import-images-modal/__stories__/*.tsx",
+  "../typescript/web/src/components/spinner/__stories__/*.tsx",
+  "../typescript/web/src/components/dataset-classes/__stories__/*.tsx",
+  "../typescript/web/src/components/pagination/__stories__/*.tsx",
+  "../typescript/web/src/components/workspace-switcher/create-workspace-modal/__stories__/*.tsx",
+  "../typescript/web/src/components/workspace-switcher/workspace-menu/workspace-selection-popover/__stories__/*.tsx",
+  "../typescript/web/src/components/workspace-switcher/workspace-menu/workspace-selection-popover/workspace-list-item/__stories__/*.tsx",
+  "../typescript/web/src/components/workspace-switcher/workspace-menu/__stories__/*.tsx",
+  "../typescript/web/src/components/toggle-button-group/__stories__/*.tsx",
+];
 
 module.exports = {
-  stories: [
-    "../typescript/**/__stories__/*.tsx",
-    "../typescript/**/*.stories.tsx",
-  ],
+  stories: STORIES,
+  // FIXME SW Uncomment the lines below once every story has been fixed following the service worker removal
+  // stories: [
+  //   "../typescript/**/__stories__/*.tsx",
+  //   "../typescript/**/*.stories.tsx",
+  // ],
   core: {
     builder: "webpack5",
   },
-  addons: [
-    "storybook-addon-next-router",
-  ],
+  addons: ["storybook-addon-next-router"],
   typescript: { reactDocgen: "react-docgen" },
   webpackFinal: async (config) => {
     return {
-      ...config ?? {},
+      ...(config ?? {}),
       resolve: {
-        ...config?.resolve ?? {},
+        ...(config?.resolve ?? {}),
         alias: {
-          ...config?.resolve?.alias ?? {},
+          ...(config?.resolve?.alias ?? {}),
           "@emotion/core": "@emotion/react",
           "emotion-theming": "@emotion/react",
         },
         fallback: {
-          ...config?.resolve?.fallback ?? {},
+          ...(config?.resolve?.fallback ?? {}),
           child_process: false,
           dgram: false,
           dns: false,
@@ -35,11 +72,11 @@ module.exports = {
         },
       },
       plugins: [
-        ...config?.plugins ?? [],
+        ...(config?.plugins ?? []),
         new NodePolyfillPlugin({
-          excludeAliases: ["console"]
-        })
-      ]
+          excludeAliases: ["console"],
+        }),
+      ],
     };
   },
 };


### PR DESCRIPTION
## Work performed

<!--- Concisely describe what was done, this will appear in the public changelog -->
I've listed the storybook directories and only included the ones which were not causing the Storybook build to fail.

## Results

<!--- Does this pull-request fully implement the new feature? If not why? Create and link new issues. -->
Storybook should work again.

## Problems encountered

<!--- Explain problems that were encountered when implementing this pull-request -->
Storybook does not print which story is causing the build to fail.

## Caveats

<!--- Any particular attention point with what you did? -->
* Each `__stories__` directory is explicitly listed in the `.storybook/main.js` file.
* We'll have to revert the changes once the stories gets fixed.

## Resolved issues

<!--- List references to issues that this PR resolves -->
No but it contributes to #848 

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
> **TODO**: Add task "Revert d320ec6855c2cfc5fd784f859e96ff4b02ed62a1" at the end of #646