### PR TITLE
Add a tutorial in every workspace created

### DIFF
--- a/data/__generated__/schema.graphql
+++ b/data/__generated__/schema.graphql
@@ -299,6 +299,19 @@ input LabelCreateInput {
   smartToolInput: JSON
 }
 
+input LabelCreateManyInput {
+  labels: [LabelCreateManySingleInput!]!
+  imageId: ID!
+}
+
+input LabelCreateManySingleInput {
+  id: ID
+  type: LabelType
+  labelClassId: ID
+  geometry: GeometryInput!
+  smartToolInput: JSON
+}
+
 enum LabelType {
   Classification
   Polygon
@@ -377,6 +390,8 @@ type Mutation {
   updateImage(where: ImageWhereUniqueInput!, data: ImageUpdateInput!): Image
   deleteImage(where: ImageWhereUniqueInput!): Image
   createLabel(data: LabelCreateInput!): Label
+  createManyLabels(data: LabelCreateManyInput!): [Label!]!
+  createManyTutorialLabels(data: TutorialLabelCreateManyInput!): [Label!]!
   updateLabel(where: LabelWhereUniqueInput!, data: LabelUpdateInput!): Label
   deleteLabel(where: LabelWhereUniqueInput!): Label
   createLabelClass(data: LabelClassCreateInput!): LabelClass
@@ -387,6 +402,7 @@ type Mutation {
   createIogLabel(data: CreateIogLabelInput!): Label
   createDataset(data: DatasetCreateInput!): Dataset
   createDemoDataset: Dataset
+  createTutorialDataset(data: TutorialDatasetCreateInput!): Dataset
   updateDataset(where: DatasetWhereUniqueInput!, data: DatasetUpdateInput!): Dataset
   deleteDataset(where: DatasetWhereUniqueInput!): Dataset
   importDataset(where: DatasetWhereUniqueInput!, data: DatasetImportInput!): ImportStatus
@@ -440,6 +456,37 @@ input RunIogInput {
   pointsInside: [[Float!]]
   pointsOutside: [[Float!]]
   centerPoint: [Float!]
+}
+
+input TutorialDatasetCreateInput {
+  id: ID
+  name: String!
+  workspaceSlug: String!
+  labelClass: TutorialLabelClassCreateInput!
+  images: [ImageCreateManySingleInput!]!
+  labels: [TutorialLabelCreateManySingleInput!]!
+}
+
+input TutorialLabelClassCreateInput {
+  name: String!
+  color: ColorHex
+}
+
+input TutorialLabelCreateManyInput {
+  labels: [TutorialLabelCreateManySingleInput!]!
+  imageId: ID!
+}
+
+input TutorialLabelCreateManySingleInput {
+  id: ID
+  type: LabelType
+  labelClassId: ID
+  geometry: GeometryInput!
+  x: Float!
+  y: Float!
+  height: Float!
+  width: Float!
+  smartToolInput: JSON
 }
 
 input UpdateIogInput {

--- a/data/dataset.graphql
+++ b/data/dataset.graphql
@@ -4,6 +4,15 @@ input DatasetCreateInput {
   workspaceSlug: String!
 }
 
+input TutorialDatasetCreateInput {
+  id: ID
+  name: String!
+  workspaceSlug: String!
+  labelClass: TutorialLabelClassCreateInput!
+  images: [ImageCreateManySingleInput!]!
+  labels: [TutorialLabelCreateManySingleInput!]!
+}
+
 input WorkspaceSlugAndDatasetSlug {
   slug: String!
   workspaceSlug: String!

--- a/data/label-class.graphql
+++ b/data/label-class.graphql
@@ -5,6 +5,11 @@ input LabelClassCreateInput {
   datasetId: ID!
 }
 
+input TutorialLabelClassCreateInput {
+  name: String!
+  color: ColorHex
+}
+
 input LabelClassUpdateInput {
   name: String
   color: ColorHex

--- a/data/label.graphql
+++ b/data/label.graphql
@@ -28,6 +28,36 @@ input GeometryInput {
   coordinates: JSON!
 }
 
+input LabelCreateManySingleInput {
+  id: ID
+  type: LabelType
+  labelClassId: ID
+  geometry: GeometryInput!
+  smartToolInput: JSON
+}
+
+input TutorialLabelCreateManySingleInput {
+  id: ID
+  type: LabelType
+  labelClassId: ID
+  geometry: GeometryInput!
+  x: Float!
+  y: Float!
+  height: Float!
+  width: Float!
+  smartToolInput: JSON
+}
+
+input LabelCreateManyInput {
+  labels: [LabelCreateManySingleInput!]!
+  imageId: ID!
+}
+
+input TutorialLabelCreateManyInput {
+  labels: [TutorialLabelCreateManySingleInput!]!
+  imageId: ID!
+}
+
 type LabelsAggregates {
   totalCount: Int!
 }

--- a/data/mutations.graphql
+++ b/data/mutations.graphql
@@ -8,6 +8,8 @@ type Mutation {
   deleteImage(where: ImageWhereUniqueInput!): Image
 
   createLabel(data: LabelCreateInput!): Label
+  createManyLabels(data: LabelCreateManyInput!): [Label!]!
+  createManyTutorialLabels(data: TutorialLabelCreateManyInput!): [Label!]!
   updateLabel(where: LabelWhereUniqueInput!, data: LabelUpdateInput!): Label
   deleteLabel(where: LabelWhereUniqueInput!): Label
 
@@ -27,6 +29,7 @@ type Mutation {
 
   createDataset(data: DatasetCreateInput!): Dataset
   createDemoDataset: Dataset
+  createTutorialDataset(data: TutorialDatasetCreateInput!): Dataset
   updateDataset(
     where: DatasetWhereUniqueInput!
     data: DatasetUpdateInput!

--- a/typescript/common-resolvers/src/data/dataset-tutorial.ts
+++ b/typescript/common-resolvers/src/data/dataset-tutorial.ts
@@ -1,4 +1,5 @@
 import { LabelType } from "@labelflow/graphql-types";
+import { LABEL_CLASS_COLOR_PALETTE } from "@labelflow/utils/src/class-color-generator";
 
 const origin =
   "location" in globalThis && typeof globalThis.location?.origin === "string"
@@ -19,31 +20,37 @@ export const tutorialImages = [
     datasetId: "049fe9f0-9a19-43cd-be65-35d222d54b4d",
     id: "2bbbf664-5810-4760-a10f-841de2f35510",
     url: `${origin}/static/img/tutorial-image-1.jpg`,
+    name: "image-1",
   },
   {
     datasetId: "049fe9f0-9a19-43cd-be65-35d222d54b4d",
     id: "506b263f-61a9-45ba-8f75-515534fae97c",
     url: `${origin}/static/img/tutorial-image-2.jpg`,
+    name: "image-2",
   },
   {
     datasetId: "049fe9f0-9a19-43cd-be65-35d222d54b4d",
     id: "04f999da-780c-461c-8e8e-c3189ae560fb",
     url: `${origin}/static/img/tutorial-image-3.jpg`,
+    name: "image-3",
   },
   {
     datasetId: "049fe9f0-9a19-43cd-be65-35d222d54b4d",
     id: "73b89fd9-0be8-4c76-bc4f-fee943b0d9d1",
     url: `${origin}/static/img/tutorial-image-4.jpg`,
+    name: "image-4",
   },
   {
     datasetId: "049fe9f0-9a19-43cd-be65-35d222d54b4d",
     id: "d96db1e2-2ecd-425e-b88f-7692a28d2dcf",
     url: `${origin}/static/img/tutorial-image-5.jpg`,
+    name: "image-5",
   },
   {
     datasetId: "049fe9f0-9a19-43cd-be65-35d222d54b4d",
     id: "dc736ae4-3c49-4081-9d75-b43e922e0ac9",
     url: `${origin}/static/img/tutorial-image-6.jpg`,
+    name: "image-6",
   },
 ];
 
@@ -52,7 +59,7 @@ export const tutorialLabelClasses = [
     id: "2b4f7ed2-4257-48f8-b546-81af73f3c904",
     index: 0,
     name: "Horse",
-    color: "#F87171",
+    color: LABEL_CLASS_COLOR_PALETTE[0],
     datasetId: "049fe9f0-9a19-43cd-be65-35d222d54b4d",
   },
 ];

--- a/typescript/common-resolvers/src/types.ts
+++ b/typescript/common-resolvers/src/types.ts
@@ -162,10 +162,20 @@ export type Repository = {
   };
   label: {
     add: Add<DbLabelCreateInput>;
+    addMany: (
+      args: {
+        labels: DbLabelCreateInput[];
+        imageId: string;
+      },
+      user?: { id: string }
+    ) => Promise<ID[]>;
     count: Count<LabelWhereInput & { user?: { id: string } }>;
     delete: Delete<LabelWhereUniqueInput>;
     get: Get<DbLabel, LabelWhereUniqueInput>;
-    list: List<DbLabel, LabelWhereInput & { user?: { id: string } }>;
+    list: List<
+      DbLabel,
+      LabelWhereInput & { user?: { id: string } } & { id?: { in: string[] } }
+    >;
     update: Update<DbLabel, LabelWhereUniqueInput>;
   };
   labelClass: {

--- a/typescript/db/src/__generated__/schema.ts
+++ b/typescript/db/src/__generated__/schema.ts
@@ -301,6 +301,19 @@ export const typeDefs = [
     smartToolInput: JSON
   }
 
+  input LabelCreateManyInput {
+    labels: [LabelCreateManySingleInput!]!
+    imageId: ID!
+  }
+
+  input LabelCreateManySingleInput {
+    id: ID
+    type: LabelType
+    labelClassId: ID
+    geometry: GeometryInput!
+    smartToolInput: JSON
+  }
+
   enum LabelType {
     Classification
     Polygon
@@ -379,6 +392,8 @@ export const typeDefs = [
     updateImage(where: ImageWhereUniqueInput!, data: ImageUpdateInput!): Image
     deleteImage(where: ImageWhereUniqueInput!): Image
     createLabel(data: LabelCreateInput!): Label
+    createManyLabels(data: LabelCreateManyInput!): [Label!]!
+    createManyTutorialLabels(data: TutorialLabelCreateManyInput!): [Label!]!
     updateLabel(where: LabelWhereUniqueInput!, data: LabelUpdateInput!): Label
     deleteLabel(where: LabelWhereUniqueInput!): Label
     createLabelClass(data: LabelClassCreateInput!): LabelClass
@@ -389,6 +404,7 @@ export const typeDefs = [
     createIogLabel(data: CreateIogLabelInput!): Label
     createDataset(data: DatasetCreateInput!): Dataset
     createDemoDataset: Dataset
+    createTutorialDataset(data: TutorialDatasetCreateInput!): Dataset
     updateDataset(where: DatasetWhereUniqueInput!, data: DatasetUpdateInput!): Dataset
     deleteDataset(where: DatasetWhereUniqueInput!): Dataset
     importDataset(where: DatasetWhereUniqueInput!, data: DatasetImportInput!): ImportStatus
@@ -442,6 +458,37 @@ export const typeDefs = [
     pointsInside: [[Float!]]
     pointsOutside: [[Float!]]
     centerPoint: [Float!]
+  }
+
+  input TutorialDatasetCreateInput {
+    id: ID
+    name: String!
+    workspaceSlug: String!
+    labelClass: TutorialLabelClassCreateInput!
+    images: [ImageCreateManySingleInput!]!
+    labels: [TutorialLabelCreateManySingleInput!]!
+  }
+
+  input TutorialLabelClassCreateInput {
+    name: String!
+    color: ColorHex
+  }
+
+  input TutorialLabelCreateManyInput {
+    labels: [TutorialLabelCreateManySingleInput!]!
+    imageId: ID!
+  }
+
+  input TutorialLabelCreateManySingleInput {
+    id: ID
+    type: LabelType
+    labelClassId: ID
+    geometry: GeometryInput!
+    x: Float!
+    y: Float!
+    height: Float!
+    width: Float!
+    smartToolInput: JSON
   }
 
   input UpdateIogInput {

--- a/typescript/db/src/repository/index.ts
+++ b/typescript/db/src/repository/index.ts
@@ -124,6 +124,12 @@ export const repository: Repository = {
       ).label.create({ data: label });
       return createdLabel.id;
     },
+    addMany: async ({ labels, imageId }, user) => {
+      await checkUserAccessToImage({ where: { id: imageId }, user });
+      const prisma = await getPrismaClient();
+      await prisma.label.createMany({ data: labels });
+      return labels.map((label) => label.id);
+    },
     count: countLabels,
     delete: async ({ id }, user) => {
       await checkUserAccessToLabel({ where: { id }, user });

--- a/typescript/graphql-types/src/graphql-types.generated.ts
+++ b/typescript/graphql-types/src/graphql-types.generated.ts
@@ -330,6 +330,19 @@ export type LabelCreateInput = {
   smartToolInput?: Maybe<Scalars['JSON']>;
 };
 
+export type LabelCreateManyInput = {
+  labels: Array<LabelCreateManySingleInput>;
+  imageId: Scalars['ID'];
+};
+
+export type LabelCreateManySingleInput = {
+  id?: Maybe<Scalars['ID']>;
+  type?: Maybe<LabelType>;
+  labelClassId?: Maybe<Scalars['ID']>;
+  geometry: GeometryInput;
+  smartToolInput?: Maybe<Scalars['JSON']>;
+};
+
 export enum LabelType {
   Classification = 'Classification',
   Polygon = 'Polygon',
@@ -411,6 +424,8 @@ export type Mutation = {
   updateImage?: Maybe<Image>;
   deleteImage?: Maybe<Image>;
   createLabel?: Maybe<Label>;
+  createManyLabels: Array<Label>;
+  createManyTutorialLabels: Array<Label>;
   updateLabel?: Maybe<Label>;
   deleteLabel?: Maybe<Label>;
   createLabelClass?: Maybe<LabelClass>;
@@ -421,6 +436,7 @@ export type Mutation = {
   createIogLabel?: Maybe<Label>;
   createDataset?: Maybe<Dataset>;
   createDemoDataset?: Maybe<Dataset>;
+  createTutorialDataset?: Maybe<Dataset>;
   updateDataset?: Maybe<Dataset>;
   deleteDataset?: Maybe<Dataset>;
   importDataset?: Maybe<ImportStatus>;
@@ -473,6 +489,16 @@ export type MutationCreateLabelArgs = {
 };
 
 
+export type MutationCreateManyLabelsArgs = {
+  data: LabelCreateManyInput;
+};
+
+
+export type MutationCreateManyTutorialLabelsArgs = {
+  data: TutorialLabelCreateManyInput;
+};
+
+
 export type MutationUpdateLabelArgs = {
   where: LabelWhereUniqueInput;
   data: LabelUpdateInput;
@@ -518,6 +544,11 @@ export type MutationCreateIogLabelArgs = {
 
 export type MutationCreateDatasetArgs = {
   data: DatasetCreateInput;
+};
+
+
+export type MutationCreateTutorialDatasetArgs = {
+  data: TutorialDatasetCreateInput;
 };
 
 
@@ -749,6 +780,37 @@ export type RunIogInput = {
   centerPoint?: Maybe<Array<Scalars['Float']>>;
 };
 
+export type TutorialDatasetCreateInput = {
+  id?: Maybe<Scalars['ID']>;
+  name: Scalars['String'];
+  workspaceSlug: Scalars['String'];
+  labelClass: TutorialLabelClassCreateInput;
+  images: Array<ImageCreateManySingleInput>;
+  labels: Array<TutorialLabelCreateManySingleInput>;
+};
+
+export type TutorialLabelClassCreateInput = {
+  name: Scalars['String'];
+  color?: Maybe<Scalars['ColorHex']>;
+};
+
+export type TutorialLabelCreateManyInput = {
+  labels: Array<TutorialLabelCreateManySingleInput>;
+  imageId: Scalars['ID'];
+};
+
+export type TutorialLabelCreateManySingleInput = {
+  id?: Maybe<Scalars['ID']>;
+  type?: Maybe<LabelType>;
+  labelClassId?: Maybe<Scalars['ID']>;
+  geometry: GeometryInput;
+  x: Scalars['Float'];
+  y: Scalars['Float'];
+  height: Scalars['Float'];
+  width: Scalars['Float'];
+  smartToolInput?: Maybe<Scalars['JSON']>;
+};
+
 export type UpdateIogInput = {
   id: Scalars['ID'];
   x?: Maybe<Scalars['Float']>;
@@ -978,6 +1040,8 @@ export type ResolversTypes = {
   LabelClassWhereUniqueInput: LabelClassWhereUniqueInput;
   LabelClassesAggregates: ResolverTypeWrapper<LabelClassesAggregates>;
   LabelCreateInput: LabelCreateInput;
+  LabelCreateManyInput: LabelCreateManyInput;
+  LabelCreateManySingleInput: LabelCreateManySingleInput;
   LabelType: LabelType;
   LabelUpdateInput: LabelUpdateInput;
   LabelWhereInput: LabelWhereInput;
@@ -993,6 +1057,10 @@ export type ResolversTypes = {
   Mutation: ResolverTypeWrapper<{}>;
   Query: ResolverTypeWrapper<{}>;
   RunIogInput: RunIogInput;
+  TutorialDatasetCreateInput: TutorialDatasetCreateInput;
+  TutorialLabelClassCreateInput: TutorialLabelClassCreateInput;
+  TutorialLabelCreateManyInput: TutorialLabelCreateManyInput;
+  TutorialLabelCreateManySingleInput: TutorialLabelCreateManySingleInput;
   UpdateIogInput: UpdateIogInput;
   Upload: ResolverTypeWrapper<Scalars['Upload']>;
   UploadTarget: ResolversTypes['UploadTargetDirect'] | ResolversTypes['UploadTargetHttp'];
@@ -1060,6 +1128,8 @@ export type ResolversParentTypes = {
   LabelClassWhereUniqueInput: LabelClassWhereUniqueInput;
   LabelClassesAggregates: LabelClassesAggregates;
   LabelCreateInput: LabelCreateInput;
+  LabelCreateManyInput: LabelCreateManyInput;
+  LabelCreateManySingleInput: LabelCreateManySingleInput;
   LabelUpdateInput: LabelUpdateInput;
   LabelWhereInput: LabelWhereInput;
   LabelWhereUniqueInput: LabelWhereUniqueInput;
@@ -1072,6 +1142,10 @@ export type ResolversParentTypes = {
   Mutation: {};
   Query: {};
   RunIogInput: RunIogInput;
+  TutorialDatasetCreateInput: TutorialDatasetCreateInput;
+  TutorialLabelClassCreateInput: TutorialLabelClassCreateInput;
+  TutorialLabelCreateManyInput: TutorialLabelCreateManyInput;
+  TutorialLabelCreateManySingleInput: TutorialLabelCreateManySingleInput;
   UpdateIogInput: UpdateIogInput;
   Upload: Scalars['Upload'];
   UploadTarget: ResolversParentTypes['UploadTargetDirect'] | ResolversParentTypes['UploadTargetHttp'];
@@ -1224,6 +1298,8 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   updateImage?: Resolver<Maybe<ResolversTypes['Image']>, ParentType, ContextType, RequireFields<MutationUpdateImageArgs, 'where' | 'data'>>;
   deleteImage?: Resolver<Maybe<ResolversTypes['Image']>, ParentType, ContextType, RequireFields<MutationDeleteImageArgs, 'where'>>;
   createLabel?: Resolver<Maybe<ResolversTypes['Label']>, ParentType, ContextType, RequireFields<MutationCreateLabelArgs, 'data'>>;
+  createManyLabels?: Resolver<Array<ResolversTypes['Label']>, ParentType, ContextType, RequireFields<MutationCreateManyLabelsArgs, 'data'>>;
+  createManyTutorialLabels?: Resolver<Array<ResolversTypes['Label']>, ParentType, ContextType, RequireFields<MutationCreateManyTutorialLabelsArgs, 'data'>>;
   updateLabel?: Resolver<Maybe<ResolversTypes['Label']>, ParentType, ContextType, RequireFields<MutationUpdateLabelArgs, 'where' | 'data'>>;
   deleteLabel?: Resolver<Maybe<ResolversTypes['Label']>, ParentType, ContextType, RequireFields<MutationDeleteLabelArgs, 'where'>>;
   createLabelClass?: Resolver<Maybe<ResolversTypes['LabelClass']>, ParentType, ContextType, RequireFields<MutationCreateLabelClassArgs, 'data'>>;
@@ -1234,6 +1310,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   createIogLabel?: Resolver<Maybe<ResolversTypes['Label']>, ParentType, ContextType, RequireFields<MutationCreateIogLabelArgs, 'data'>>;
   createDataset?: Resolver<Maybe<ResolversTypes['Dataset']>, ParentType, ContextType, RequireFields<MutationCreateDatasetArgs, 'data'>>;
   createDemoDataset?: Resolver<Maybe<ResolversTypes['Dataset']>, ParentType, ContextType>;
+  createTutorialDataset?: Resolver<Maybe<ResolversTypes['Dataset']>, ParentType, ContextType, RequireFields<MutationCreateTutorialDatasetArgs, 'data'>>;
   updateDataset?: Resolver<Maybe<ResolversTypes['Dataset']>, ParentType, ContextType, RequireFields<MutationUpdateDatasetArgs, 'where' | 'data'>>;
   deleteDataset?: Resolver<Maybe<ResolversTypes['Dataset']>, ParentType, ContextType, RequireFields<MutationDeleteDatasetArgs, 'where'>>;
   importDataset?: Resolver<Maybe<ResolversTypes['ImportStatus']>, ParentType, ContextType, RequireFields<MutationImportDatasetArgs, 'where' | 'data'>>;

--- a/typescript/web/src/components/import-button/import-images-modal/modal-url-list/import-urls.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-url-list/import-urls.tsx
@@ -6,7 +6,7 @@ import { DroppedUrl, SetUploadStatuses } from "../types";
 
 import { BATCH_SIZE, CONCURRENCY } from "../constants";
 
-const CREATE_MANY_IMAGES_MUTATION = gql`
+export const CREATE_MANY_IMAGES_MUTATION = gql`
   mutation CreateManyImagesMutation(
     $images: [ImageCreateManySingleInput!]!
     $datasetId: ID!

--- a/typescript/web/src/components/workspace-switcher/create-workspace-modal/create-tutorial-dataset.ts
+++ b/typescript/web/src/components/workspace-switcher/create-workspace-modal/create-tutorial-dataset.ts
@@ -1,0 +1,88 @@
+import { gql, useMutation } from "@apollo/client";
+import {
+  tutorialImages,
+  tutorialLabelClasses,
+  tutorialLabels,
+} from "@labelflow/common-resolvers/src/data/dataset-tutorial";
+import { omit } from "lodash/fp";
+import { useCallback } from "react";
+import {
+  CreateTutorialDatasetMutation,
+  CreateTutorialDatasetMutationVariables,
+} from "../../../graphql-types/CreateTutorialDatasetMutation";
+import { useTutorialLoadingStore } from "../../../utils/use-loading-store";
+
+const CREATE_TUTORIAL_DATASET_MUTATION = gql`
+  mutation CreateTutorialDatasetMutation(
+    $name: String!
+    $workspaceSlug: String!
+    $labelClass: TutorialLabelClassCreateInput!
+    $images: [ImageCreateManySingleInput!]!
+    $labels: [TutorialLabelCreateManySingleInput!]!
+  ) {
+    createTutorialDataset(
+      data: {
+        name: $name
+        workspaceSlug: $workspaceSlug
+        labelClass: $labelClass
+        images: $images
+        labels: $labels
+      }
+    ) {
+      id
+    }
+  }
+`;
+
+export const useCreateTutorialDataset = () => {
+  const [createTutorialDatasetMutate] = useMutation<
+    CreateTutorialDatasetMutation,
+    CreateTutorialDatasetMutationVariables
+  >(CREATE_TUTORIAL_DATASET_MUTATION);
+  const setTutorialDatasetLoading = useTutorialLoadingStore(
+    (state) => state.setTutorialDatasetLoading
+  );
+  const labelClass = tutorialLabelClasses[0];
+  const now = new Date();
+  const imagesToCreate = tutorialImages.map(({ name, url }, urlIndex) => {
+    const createdAt = new Date();
+    createdAt.setTime(now.getTime() + urlIndex);
+
+    return {
+      externalUrl: url,
+      name,
+      createdAt: createdAt.toISOString(),
+      noThumbnails: true,
+    };
+  });
+  const labels = tutorialLabels.map((label) => ({
+    ...omit(["id", "imageId"], label),
+  }));
+
+  return useCallback(
+    async (workspaceSlug: string) => {
+      setTutorialDatasetLoading(true);
+      await createTutorialDatasetMutate({
+        variables: {
+          name: "Tutorial Dataset",
+          workspaceSlug,
+          labelClass: {
+            name: labelClass.name,
+            color: labelClass.color,
+          },
+          images: imagesToCreate,
+          labels,
+        },
+      });
+      setTutorialDatasetLoading(false);
+    },
+    [
+      createTutorialDatasetMutate,
+      imagesToCreate,
+      labelClass.color,
+      labelClass.name,
+      labels,
+      setTutorialDatasetLoading,
+    ]
+  );
+};

--- a/typescript/web/src/components/workspace-switcher/create-workspace-modal/create-workspace-button.tsx
+++ b/typescript/web/src/components/workspace-switcher/create-workspace-modal/create-workspace-button.tsx
@@ -1,0 +1,18 @@
+import { Button } from "@chakra-ui/react";
+import { FC } from "react";
+
+export const CreateWorkspaceButton: FC<{
+  isDisabled?: boolean;
+  isLoading?: boolean;
+}> = ({ isDisabled, isLoading }) => (
+  <Button
+    width="full"
+    type="submit"
+    isDisabled={isDisabled}
+    colorScheme="brand"
+    aria-label="create workspace button"
+    isLoading={isLoading}
+  >
+    Create
+  </Button>
+);

--- a/typescript/web/src/components/workspace-switcher/create-workspace-modal/create-workspace-modal.tsx
+++ b/typescript/web/src/components/workspace-switcher/create-workspace-modal/create-workspace-modal.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  Button,
   Heading,
   Modal,
   ModalBody,
@@ -15,7 +14,6 @@ import {
 import { isEmpty, isNil } from "lodash/fp";
 import React, {
   createContext,
-  FC,
   FormEvent,
   useCallback,
   useContext,
@@ -32,6 +30,7 @@ import {
   WorkspaceNameInputProvider,
   WorkspaceNameMessage,
 } from "../../workspace-name-input";
+import { CreateWorkspaceButton } from "./create-workspace-button";
 import { useCreateWorkspaceMutation } from "./create-workspace.mutation";
 
 const ModalIsOpenContext = createContext(false);
@@ -96,18 +95,6 @@ const WorkspaceName = ({ error }: { error: string | undefined }) => {
   );
 };
 
-const CreateButton: FC<{ isDisabled?: boolean }> = ({ isDisabled }) => (
-  <Button
-    width="full"
-    type="submit"
-    isDisabled={isDisabled}
-    colorScheme="brand"
-    aria-label="create workspace button"
-  >
-    Create
-  </Button>
-);
-
 export const useCreateWorkspace = (): [
   () => void,
   boolean,
@@ -142,7 +129,7 @@ const FormBody = () => {
   return (
     <form onSubmit={handleSubmit}>
       <WorkspaceName error={createError} />
-      <CreateButton isDisabled={isDisabled} />
+      <CreateWorkspaceButton isDisabled={isDisabled} isLoading={isLoading} />
     </form>
   );
 };

--- a/typescript/web/src/components/workspace-switcher/create-workspace-modal/create-workspace.mutation.ts
+++ b/typescript/web/src/components/workspace-switcher/create-workspace-modal/create-workspace.mutation.ts
@@ -22,6 +22,7 @@ import {
 } from "../../../graphql-types/CreateWorkspaceMutation";
 import { USER_WITH_WORKSPACES_QUERY } from "../../../shared-queries/user.query";
 import { BoolParam } from "../../../utils/query-param-bool";
+import { useCreateTutorialDataset } from "./create-tutorial-dataset";
 
 export const CREATE_WORKSPACE_MUTATION = gql`
   mutation CreateWorkspaceMutation($name: String!) {
@@ -80,13 +81,15 @@ const useCreateWorkspaceMutationError = (
 
 const useCreateWorkspaceMutationCompleted = () => {
   const router = useRouter();
+  const createTutorialDataset = useCreateTutorialDataset();
   return useCallback(
     ({ createWorkspace }: CreateWorkspaceMutation) => {
       if (!isNil(createWorkspace)) {
+        createTutorialDataset(createWorkspace.slug);
         router.push(`/${createWorkspace.slug}`);
       }
     },
-    [router]
+    [createTutorialDataset, router]
   );
 };
 

--- a/typescript/web/src/components/workspaces/workspaces.tsx
+++ b/typescript/web/src/components/workspaces/workspaces.tsx
@@ -1,6 +1,6 @@
-import { Button, Center, chakra, Flex, Heading, Text } from "@chakra-ui/react";
+import { Center, chakra, Flex, Heading, Text } from "@chakra-ui/react";
 import { isEmpty } from "lodash";
-import { FC, useCallback, FormEvent } from "react";
+import { useCallback, FormEvent } from "react";
 import { useWorkspaces } from "../../hooks";
 import NoWorkspacesGraphics from "../graphics/no-workspace";
 import {
@@ -10,6 +10,7 @@ import {
   WorkspaceNameMessage,
 } from "../workspace-name-input";
 import { useCreateWorkspace } from "../workspace-switcher/create-workspace-modal";
+import { CreateWorkspaceButton } from "../workspace-switcher/create-workspace-modal/create-workspace-button";
 import {
   WorkspacesContextProvider,
   WorkspacesProps,
@@ -17,19 +18,6 @@ import {
 import { WorkspacesList } from "./workspaces-list";
 
 const ChakraNoWorkspaces = chakra(NoWorkspacesGraphics);
-
-const CreateButton: FC<{ isDisabled?: boolean }> = ({ isDisabled }) => (
-  <Button
-    width="full"
-    type="submit"
-    isDisabled={isDisabled}
-    colorScheme="brand"
-    aria-label="create workspace button"
-    mt="8"
-  >
-    Create
-  </Button>
-);
 
 const useSubmitForm = (isDisabled: boolean, create: () => void) =>
   useCallback(
@@ -54,7 +42,7 @@ const CreateWorkspaceForm = () => {
       <form onSubmit={handleSubmit} style={{ width: "100%" }}>
         <WorkspaceNameInput hideInvalid={empty} bgColor="white" />
         <WorkspaceNameMessage customError={createError} hideError={empty} />
-        <CreateButton isDisabled={isDisabled} />
+        <CreateWorkspaceButton isDisabled={isDisabled} isLoading={isLoading} />
       </form>
     </Flex>
   );

--- a/typescript/web/src/hooks/use-user.tsx
+++ b/typescript/web/src/hooks/use-user.tsx
@@ -78,6 +78,7 @@ const useWorkspaceProvider = () => {
     () => workspaces?.find(({ slug }) => slug === workspaceSlug),
     [workspaceSlug, workspaces]
   );
+  // FIXME: That 'if' is causing problems on workspace creation and deletion
   if (!isNil(workspaces) && !isEmpty(workspaceSlug) && isNil(workspace)) {
     const msg = `Could not find any workspace with slug ${workspaceSlug}`;
     throw new Error(msg);

--- a/typescript/web/src/pages/[workspaceSlug]/datasets/index.tsx
+++ b/typescript/web/src/pages/[workspaceSlug]/datasets/index.tsx
@@ -1,7 +1,15 @@
 import React, { useCallback } from "react";
 import { useQuery } from "@apollo/client";
 
-import { Flex, Text } from "@chakra-ui/react";
+import {
+  AspectRatio,
+  Box,
+  Flex,
+  Skeleton,
+  Text,
+  useColorModeValue as mode,
+  VStack,
+} from "@chakra-ui/react";
 
 import { useQueryParam } from "use-query-params";
 
@@ -30,6 +38,8 @@ import {
   WorkspaceDatasetsPageDatasetsQueryVariables,
 } from "../../../graphql-types/WorkspaceDatasetsPageDatasetsQuery";
 import { useWorkspace } from "../../../hooks";
+import { useTutorialLoadingStore } from "../../../utils/use-loading-store";
+import { EmptyStateNoImages } from "../../../components/empty-state";
 
 const LoadingCard = () => (
   <DatasetCardBox>
@@ -45,16 +55,47 @@ const LoadingCard = () => (
   </DatasetCardBox>
 );
 
+const TutorialLoadingCard = () => (
+  <DatasetCardBox>
+    <Box
+      zIndex="1"
+      as="a"
+      w="100%"
+      h="2xs"
+      borderWidth="0px"
+      borderRadius="16px"
+      overflow="hidden"
+      bg={mode("white", "gray.700")}
+      display="block"
+      cursor="pointer"
+    >
+      <AspectRatio maxH="32">
+        <EmptyStateNoImages />
+      </AspectRatio>
+      <VStack pt="2" pl="5" pr="5" pb="5" align="center">
+        <Text color={mode("gray.600", "gray.300")}>
+          Your tutorial dataset is being loaded
+        </Text>
+        <Skeleton height="30px" width="90%" />
+        <Skeleton height="30px" width="90%" />
+      </VStack>
+    </Box>
+  </DatasetCardBox>
+);
+
 const Body = () => {
   const { slug: workspaceSlug } = useWorkspace();
   const { isReady } = useRouter();
+  const isTutorialLoading = useTutorialLoadingStore(
+    (state) => state.tutorialDatasetLoading
+  );
 
   const { data: datasetsResult, loading } = useQuery<
     WorkspaceDatasetsPageDatasetsQuery,
     WorkspaceDatasetsPageDatasetsQueryVariables
   >(WORKSPACE_DATASETS_PAGE_DATASETS_QUERY, {
     variables: { where: { workspaceSlug } },
-    skip: isEmpty(workspaceSlug),
+    skip: isEmpty(workspaceSlug) || isTutorialLoading,
   });
 
   const [isCreatingDataset, setIsCreatingDataset] = useQueryParam(
@@ -123,6 +164,7 @@ const Body = () => {
               setIsCreatingDataset(true, "replaceIn");
             }}
           />
+          {isTutorialLoading && <TutorialLoadingCard />}
           {loading ? (
             <LoadingCard />
           ) : (

--- a/typescript/web/src/utils/use-loading-store.ts
+++ b/typescript/web/src/utils/use-loading-store.ts
@@ -1,0 +1,12 @@
+import create from "zustand";
+
+type TutorialLoadingState = {
+  tutorialDatasetLoading: boolean;
+  setTutorialDatasetLoading: (value: boolean) => void;
+};
+
+export const useTutorialLoadingStore = create<TutorialLoadingState>((set) => ({
+  tutorialDatasetLoading: false,
+  setTutorialDatasetLoading: (newValue: boolean) =>
+    set(() => ({ tutorialDatasetLoading: newValue })),
+}));


### PR DESCRIPTION
## Work performed

- Add a tutorial in every workspace created

## Result

A tutorial dataset will now be injected in every workspace created. The data inside remains the same than when we used to do it in the service worker. 

## Problems encountered

An error is thrown on each workspace created or deleted.
If you reload the page, the error does not appear anymore.

## Resolved issues

Closes #777 