### PR TITLE
Fix timeout on label export

### DIFF
--- a/typescript/common-resolvers/src/export/format-coco/add-image-dimensions-to-labels.ts
+++ b/typescript/common-resolvers/src/export/format-coco/add-image-dimensions-to-labels.ts
@@ -1,25 +1,15 @@
 import { DbLabel, DbImage } from "../../types";
 
-type ImageDimensions = {
-  width: number;
-  height: number;
-};
+type ImageDimensions = Pick<DbImage, "width" | "height">;
 
 export const addImageDimensionsToLabels = (
   labels: DbLabel[],
   images: DbImage[]
 ) => {
-  const dimensionsByImage = images.reduce(
-    (acc: { [imageId: string]: ImageDimensions }, image) => {
-      const key = image.id;
-      if (!acc[key]) {
-        acc[key] = { width: image.width, height: image.height };
-      }
-      return acc;
-    },
+  const dimensionsByImage = images.reduce<Record<string, ImageDimensions>>(
+    (prev, { id, width, height }) => ({ ...prev, [id]: { width, height } }),
     {}
   );
-
   return labels.map((label) => ({
     ...label,
     imageDimensions: dimensionsByImage[label.imageId],

--- a/typescript/common-resolvers/src/export/format-coco/add-image-dimensions-to-labels.ts
+++ b/typescript/common-resolvers/src/export/format-coco/add-image-dimensions-to-labels.ts
@@ -1,5 +1,4 @@
-import { DbImage } from "../..";
-import { DbLabel } from "../../types";
+import { DbLabel, DbImage } from "../../types";
 
 type ImageDimensions = {
   width: number;

--- a/typescript/common-resolvers/src/export/format-coco/coco-core/__tests__/converters.ts
+++ b/typescript/common-resolvers/src/export/format-coco/coco-core/__tests__/converters.ts
@@ -216,7 +216,6 @@ describe("Coco converters", () => {
       width: 2,
       coco_url: "https://an-image",
       file_name: "an-image_id-an-image.png",
-      flickr_url: "",
       license: 0,
     });
 
@@ -231,7 +230,6 @@ describe("Coco converters", () => {
       width: 2,
       coco_url: "https://an-image",
       file_name: "an-image.png",
-      flickr_url: "",
       license: 0,
     });
   });

--- a/typescript/common-resolvers/src/export/format-coco/coco-core/converters.ts
+++ b/typescript/common-resolvers/src/export/format-coco/coco-core/converters.ts
@@ -168,7 +168,6 @@ const convertImageToCocoImage = (
     )}.${mime.extension(mimetype)}`,
     coco_url: externalUrl ?? "",
     date_captured: createdAt,
-    flickr_url: "",
     height,
     width,
     license: 0,

--- a/typescript/common-resolvers/src/export/format-coco/coco-core/types.ts
+++ b/typescript/common-resolvers/src/export/format-coco/coco-core/types.ts
@@ -38,7 +38,6 @@ export type CocoImage = {
   height: number;
   file_name: string;
   license: number;
-  flickr_url: string;
   coco_url: string;
   date_captured: string;
 };

--- a/typescript/common-resolvers/src/export/format-coco/export-to-coco.ts
+++ b/typescript/common-resolvers/src/export/format-coco/export-to-coco.ts
@@ -19,11 +19,7 @@ export const exportToCoco: ExportFunction = async (
   const labelClasses = await repository.labelClass.list({ datasetId, user });
   const labels = await repository.label.list({ datasetId, user });
 
-  const labelsWithImageDimensions = await addImageDimensionsToLabels(
-    labels,
-    repository,
-    user
-  );
+  const labelsWithImageDimensions = addImageDimensionsToLabels(labels, images);
   const annotationsFileJson = JSON.stringify(
     convertLabelflowDatasetToCocoDataset(
       images,

--- a/typescript/common-resolvers/src/export/format-yolo/export-to-yolo.ts
+++ b/typescript/common-resolvers/src/export/format-yolo/export-to-yolo.ts
@@ -1,4 +1,5 @@
 import { ExportOptionsYolo, LabelType } from "@labelflow/graphql-types";
+import { isEmpty, groupBy } from "lodash/fp";
 import JSZip from "jszip";
 import mime from "mime-types";
 import { DbImage, DbLabel, DbLabelClass } from "../../types";
@@ -7,16 +8,7 @@ import { getImageName } from "../common";
 import { ExportFunction } from "../types";
 
 const groupLabelsByImage = (labelsArray: DbLabel[]) => {
-  return labelsArray
-    ? labelsArray.reduce((acc: { [imageId: string]: DbLabel[] }, label) => {
-        const key = label.imageId;
-        if (!acc[key]) {
-          acc[key] = [];
-        }
-        acc[key].push(label);
-        return acc;
-      }, {})
-    : {};
+  return isEmpty(labelsArray) ? {} : groupBy("imageId", labelsArray);
 };
 
 export const generateNamesFile = (labelClasses: DbLabelClass[]): string => {


### PR DESCRIPTION
## Work performed

- Rework the way labels are exported
- Remove unused flickr_url

## Results

The labels, labelClasses and images of a dataset are now queried once for all at the beginning of the export procedure. A temporary object is built for fast access when iterating over the labels / images.

Tests I've conducted over a 11000+ labels dataset:
- yolo export -> From ~20s to ~10s
- coco export -> From `timeout` to ~8s

## Caveats

The tests were **only** focusing on labels and not images. If too much timeouts because of images happen, there is another way we could potentially improve performances:

- In both COCO and YOLO exports, for each image, this query is executed: `await repository.upload.get(image.url, req);`, returning an `ArrayBuffer` of the to-be-exported image. We could potentially batch these calls as we already have the full list of the dataset's images.

## Resolved issues

Closes #844 
