### PR TITLE
Add Jest tests coverage to CodeClimate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,9 +156,33 @@ jobs:
         env:
           POSTGRES_EXTERNAL_URL: postgresql://admin:admin@localhost:5433/labelflow?schema=public
       - name: run tests
-        run: yarn test
+        run: yarn test --coverage
         env:
           POSTGRES_EXTERNAL_URL: postgresql://admin:admin@localhost:5433/labelflow?schema=public
+      - name: Upload code-coverage output
+        uses: actions/upload-artifact@v2
+        with:
+          name: lcov.info
+          path: coverage/lcov.info
+
+  publish-tests-coverage:
+    name: Publish tests code-coverage to CodeClimate
+    runs-on: ubuntu-20.04
+    needs: test-typescript
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Download code-coverage output
+        uses: actions/download-artifact@v2
+        with:
+          name: lcov.info
+      - name: Publish code-coverage output to CodeClimate
+        uses: paambaati/codeclimate-action@v3.0.0
+        env:
+          CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
+        with:
+          coverageLocations: |
+            lcov.info:lcov
 
   check-codegen-diff:
     name: Check diff after codegen

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -21,11 +21,13 @@ export default {
       displayName: "browser",
       preset: "ts-jest",
       collectCoverage: true,
+      coverageReporters: ["lcov"],
       testPathIgnorePatterns: ["node_modules"],
       setupFilesAfterEnv: ["<rootDir>/setup-tests.ts"],
       globals: {
         "ts-jest": {
           tsconfig: "tsconfig.jest.json",
+          isolatedModules: true,
         },
       },
       transform: {
@@ -46,11 +48,13 @@ export default {
       displayName: "nodejs",
       preset: "ts-jest",
       collectCoverage: true,
+      coverageReporters: ["lcov"],
       testPathIgnorePatterns: ["node_modules"],
       setupFilesAfterEnv: ["<rootDir>/setup-tests.ts"],
       globals: {
         "ts-jest": {
           tsconfig: "tsconfig.jest.json",
+          isolatedModules: true,
         },
       },
       transform: {


### PR DESCRIPTION
## Work performed

- Change Jest tests config to generate an lcov coverage report
- Add a CI action to publish lcov data to CodeClimate

## Results

