### PR TITLE
Fix coco import fail when containing crowd RLE annotations

### DIFF
--- a/data/__generated__/schema.graphql
+++ b/data/__generated__/schema.graphql
@@ -224,6 +224,7 @@ input ImportOptionsCoco {
 
 type ImportStatus {
   error: String
+  skippedCrowdAnnotations: Int!
 }
 
 enum InvitationResult {

--- a/data/__generated__/schema.graphql
+++ b/data/__generated__/schema.graphql
@@ -224,7 +224,7 @@ input ImportOptionsCoco {
 
 type ImportStatus {
   error: String
-  skippedCrowdAnnotations: Int!
+  warnings: [String!]!
 }
 
 enum InvitationResult {

--- a/data/__generated__/schema.graphql
+++ b/data/__generated__/schema.graphql
@@ -224,7 +224,7 @@ input ImportOptionsCoco {
 
 type ImportStatus {
   error: String
-  warnings: [String!]!
+  warnings: [String!]
 }
 
 enum InvitationResult {

--- a/data/import.graphql
+++ b/data/import.graphql
@@ -1,5 +1,6 @@
 type ImportStatus{
     error: String
+    skippedCrowdAnnotations: Int!
 }
 
 input ImportOptionsCoco {

--- a/data/import.graphql
+++ b/data/import.graphql
@@ -1,6 +1,6 @@
 type ImportStatus{
     error: String
-    warnings: [String!]!
+    warnings: [String!]
 }
 
 input ImportOptionsCoco {

--- a/data/import.graphql
+++ b/data/import.graphql
@@ -1,6 +1,6 @@
 type ImportStatus{
     error: String
-    skippedCrowdAnnotations: Int!
+    warnings: [String!]!
 }
 
 input ImportOptionsCoco {

--- a/typescript/common-resolvers/src/import/format-coco/index.ts
+++ b/typescript/common-resolvers/src/import/format-coco/index.ts
@@ -231,9 +231,6 @@ async function importCocoAnnotationsIntoLabels(
       }
       if (annotation.iscrowd === 1) {
         skippedCrowdAnnotations += 1;
-        console.log(
-          `Skipped annotation ${annotation.id}: crowd/RLE format no yet supported`
-        );
         return;
       }
       await labelResolvers.Mutation.createLabel(
@@ -290,5 +287,12 @@ export const importCoco: ImportFunction = async (
     cocoCategoryIdToLabelFlowLabelClassId,
     { repository, req, user }
   );
-  return { skippedCrowdAnnotations };
+  return {
+    warnings:
+      skippedCrowdAnnotations > 0
+        ? [
+            `${skippedCrowdAnnotations} RLE bitmap annotations were ignored.\nOnly polygon annotations are supported.`,
+          ]
+        : [],
+  };
 };

--- a/typescript/common-resolvers/src/import/format-coco/index.ts
+++ b/typescript/common-resolvers/src/import/format-coco/index.ts
@@ -297,7 +297,5 @@ export const importCoco: ImportFunction = async (
     cocoCategoryIdToLabelFlowLabelClassId,
     { repository, req, user }
   );
-  return {
-    warnings: warning ? [warning] : [],
-  };
+  return { warnings: warning ? [warning] : undefined };
 };

--- a/typescript/common-resolvers/src/import/index.ts
+++ b/typescript/common-resolvers/src/import/index.ts
@@ -10,7 +10,7 @@ import { Context } from "../types";
 const makeImport = async (
   args: MutationImportDatasetArgs,
   { repository, req, user }: Context
-): Promise<void> => {
+): Promise<ImportStatus> => {
   const datasetBlob = new Blob(
     [await repository.upload.get(args.data.url, req)],
     {
@@ -29,7 +29,7 @@ const makeImport = async (
       throw new Error("YOLO format not supported, but will be soon!");
     }
     case ExportFormat.Coco: {
-      return importCoco(
+      return await importCoco(
         datasetBlob,
         args.where?.id,
         {
@@ -52,11 +52,11 @@ const importDataset = async (
   { repository, req, user }: Context
 ): Promise<ImportStatus> => {
   try {
-    await makeImport(args, { repository, req, user });
-    return {};
+    return await makeImport(args, { repository, req, user });
   } catch (e) {
     return {
       error: `${e.message}\n${e.stack}`,
+      skippedCrowdAnnotations: 0,
     };
   }
 };

--- a/typescript/common-resolvers/src/import/index.ts
+++ b/typescript/common-resolvers/src/import/index.ts
@@ -56,7 +56,7 @@ const importDataset = async (
   } catch (e) {
     return {
       error: `${e.message}\n${e.stack}`,
-      warnings: [],
+      warnings: undefined,
     };
   }
 };

--- a/typescript/common-resolvers/src/import/index.ts
+++ b/typescript/common-resolvers/src/import/index.ts
@@ -29,7 +29,7 @@ const makeImport = async (
       throw new Error("YOLO format not supported, but will be soon!");
     }
     case ExportFormat.Coco: {
-      return await importCoco(
+      return importCoco(
         datasetBlob,
         args.where?.id,
         {
@@ -56,7 +56,7 @@ const importDataset = async (
   } catch (e) {
     return {
       error: `${e.message}\n${e.stack}`,
-      skippedCrowdAnnotations: 0,
+      warnings: [],
     };
   }
 };

--- a/typescript/common-resolvers/src/import/index.ts
+++ b/typescript/common-resolvers/src/import/index.ts
@@ -29,7 +29,7 @@ const makeImport = async (
       throw new Error("YOLO format not supported, but will be soon!");
     }
     case ExportFormat.Coco: {
-      return importCoco(
+      return await importCoco(
         datasetBlob,
         args.where?.id,
         {

--- a/typescript/common-resolvers/src/import/types.ts
+++ b/typescript/common-resolvers/src/import/types.ts
@@ -1,4 +1,4 @@
-import { ImportOptionsCoco } from "@labelflow/graphql-types";
+import { ImportOptionsCoco, ImportStatus } from "@labelflow/graphql-types";
 import { Context } from "../types";
 
 export type ImportFunction = (
@@ -6,4 +6,4 @@ export type ImportFunction = (
   datasetId: string,
   context: Context,
   options?: ImportOptionsCoco
-) => void;
+) => Promise<ImportStatus>;

--- a/typescript/db/src/__generated__/schema.ts
+++ b/typescript/db/src/__generated__/schema.ts
@@ -226,7 +226,7 @@ export const typeDefs = [
 
   type ImportStatus {
     error: String
-    warnings: [String!]!
+    warnings: [String!]
   }
 
   enum InvitationResult {

--- a/typescript/db/src/__generated__/schema.ts
+++ b/typescript/db/src/__generated__/schema.ts
@@ -226,7 +226,7 @@ export const typeDefs = [
 
   type ImportStatus {
     error: String
-    skippedCrowdAnnotations: Int!
+    warnings: [String!]!
   }
 
   enum InvitationResult {

--- a/typescript/db/src/__generated__/schema.ts
+++ b/typescript/db/src/__generated__/schema.ts
@@ -226,6 +226,7 @@ export const typeDefs = [
 
   type ImportStatus {
     error: String
+    skippedCrowdAnnotations: Int!
   }
 
   enum InvitationResult {

--- a/typescript/graphql-types/src/graphql-types.generated.ts
+++ b/typescript/graphql-types/src/graphql-types.generated.ts
@@ -252,6 +252,7 @@ export type ImportOptionsCoco = {
 export type ImportStatus = {
   __typename?: 'ImportStatus';
   error?: Maybe<Scalars['String']>;
+  skippedCrowdAnnotations: Scalars['Int'];
 };
 
 export enum InvitationResult {
@@ -1179,6 +1180,7 @@ export type ImagesAggregatesResolvers<ContextType = any, ParentType extends Reso
 
 export type ImportStatusResolvers<ContextType = any, ParentType extends ResolversParentTypes['ImportStatus'] = ResolversParentTypes['ImportStatus']> = {
   error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  skippedCrowdAnnotations?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/typescript/graphql-types/src/graphql-types.generated.ts
+++ b/typescript/graphql-types/src/graphql-types.generated.ts
@@ -252,7 +252,7 @@ export type ImportOptionsCoco = {
 export type ImportStatus = {
   __typename?: 'ImportStatus';
   error?: Maybe<Scalars['String']>;
-  skippedCrowdAnnotations: Scalars['Int'];
+  warnings: Array<Scalars['String']>;
 };
 
 export enum InvitationResult {
@@ -1180,7 +1180,7 @@ export type ImagesAggregatesResolvers<ContextType = any, ParentType extends Reso
 
 export type ImportStatusResolvers<ContextType = any, ParentType extends ResolversParentTypes['ImportStatus'] = ResolversParentTypes['ImportStatus']> = {
   error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  skippedCrowdAnnotations?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  warnings?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/typescript/graphql-types/src/graphql-types.generated.ts
+++ b/typescript/graphql-types/src/graphql-types.generated.ts
@@ -252,7 +252,7 @@ export type ImportOptionsCoco = {
 export type ImportStatus = {
   __typename?: 'ImportStatus';
   error?: Maybe<Scalars['String']>;
-  warnings: Array<Scalars['String']>;
+  warnings?: Maybe<Array<Scalars['String']>>;
 };
 
 export enum InvitationResult {
@@ -1180,7 +1180,7 @@ export type ImagesAggregatesResolvers<ContextType = any, ParentType extends Reso
 
 export type ImportStatusResolvers<ContextType = any, ParentType extends ResolversParentTypes['ImportStatus'] = ResolversParentTypes['ImportStatus']> = {
   error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  warnings?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  warnings?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/typescript/web/src/components/import-button/import-images-modal/import-images-modal.test.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/import-images-modal.test.tsx
@@ -74,18 +74,20 @@ describe(ImportImagesModal, () => {
     const { getByLabelText } = await renderTestAndImport(files.slice(0, 1));
     await waitFor(() => expect(getByLabelText("Upload succeed")).toBeDefined());
   });
-
   it("displays an indicator when upload failed", async () => {
-    const { getByLabelText } = await renderTestAndImport(
+    const { getAllByTestId } = await renderTestAndImport(
       files.slice(0, 1),
       { isOpen: true },
       true
     );
     await waitFor(() =>
-      expect(getByLabelText("Error indicator")).toBeDefined()
+      expect(
+        getAllByTestId("import-progress-tooltip-icon")[0].getAttribute(
+          "aria-label"
+        )
+      ).toBe("Error indicator")
     );
   });
-
   it("displays a loading indicator when a file is uploading", async () => {
     const { getByLabelText } = await renderTestAndImport(files.slice(0, 1));
     expect(getByLabelText("Loading indicator")).toBeDefined();

--- a/typescript/web/src/components/import-button/import-images-modal/import-progress.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/import-progress.tsx
@@ -1,56 +1,76 @@
-import { Tooltip, chakra } from "@chakra-ui/react";
-
+import { chakra, ChakraComponent, Tooltip } from "@chakra-ui/react";
+import { IconType } from "react-icons/lib";
 import {
   RiCheckboxCircleFill,
-  RiErrorWarningFill,
   RiContrastFill,
+  RiErrorWarningFill,
 } from "react-icons/ri";
+import { FileUploadInfo } from "./types";
 
 export const SucceedIcon = chakra(RiCheckboxCircleFill);
 export const LoadingIcon = chakra(RiContrastFill);
 export const ErrorIcon = chakra(RiErrorWarningFill);
 
-export const ImportProgress = ({ status }: { status: boolean | string }) => {
-  if (typeof status === "string") {
-    return (
-      <Tooltip label={status} placement="left">
-        <span>
-          <ErrorIcon
-            display="inline-block"
-            fontSize="xl"
-            color="red.500"
-            aria-label="Error indicator"
-          />
-        </span>
-      </Tooltip>
-    );
-  }
+export type ImportProgressTooltipProps = {
+  label: string;
+  icon: ChakraComponent<IconType, {}>;
+  color: string;
+  "aria-label": string;
+};
 
-  if (status) {
-    return (
-      <Tooltip label="Upload succeed" placement="left">
-        <span>
-          <SucceedIcon
-            display="inline-block"
-            fontSize="xl"
-            color="green.500"
-            aria-label="Upload succeed"
-          />
-        </span>
-      </Tooltip>
-    );
-  }
-
+export const ImportProgressTooltip = ({
+  label,
+  icon,
+  color,
+  "aria-label": ariaLabel,
+}: ImportProgressTooltipProps) => {
+  const IconComponent = icon;
   return (
-    <Tooltip label="Upload in progress" placement="left">
+    <Tooltip label={label} placement="left">
       <span>
-        <LoadingIcon
+        <IconComponent
           display="inline-block"
           fontSize="xl"
-          color="gray.800"
-          aria-label="Loading indicator"
+          color={color}
+          aria-label={ariaLabel}
         />
       </span>
     </Tooltip>
   );
+};
+
+export const ImportProgress = ({
+  fileUploadInfo,
+}: {
+  fileUploadInfo: FileUploadInfo;
+}) => {
+  switch (fileUploadInfo.status) {
+    case "error":
+      return (
+        <ImportProgressTooltip
+          label={fileUploadInfo.error!}
+          icon={ErrorIcon}
+          color="red.500"
+          aria-label="Error indicator"
+        />
+      );
+    case "uploaded":
+      return (
+        <ImportProgressTooltip
+          label="Upload succeed"
+          icon={SucceedIcon}
+          color="green.500"
+          aria-label="Upload succeed"
+        />
+      );
+    default:
+      return (
+        <ImportProgressTooltip
+          label="Upload in progress"
+          icon={LoadingIcon}
+          color="gray.800"
+          aria-label="Loading indicator"
+        />
+      );
+  }
 };

--- a/typescript/web/src/components/import-button/import-images-modal/import-progress.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/import-progress.tsx
@@ -5,7 +5,7 @@ import {
   RiContrastFill,
   RiErrorWarningFill,
 } from "react-icons/ri";
-import { FileUploadInfo } from "./types";
+import { UploadInfo } from "./types";
 
 export const SucceedIcon = chakra(RiCheckboxCircleFill);
 export const LoadingIcon = chakra(RiContrastFill);
@@ -39,16 +39,14 @@ export const ImportProgressTooltip = ({
   );
 };
 
-export const ImportProgress = ({
-  fileUploadInfo,
-}: {
-  fileUploadInfo: FileUploadInfo;
-}) => {
-  switch (fileUploadInfo.status) {
+export type ImportProgressProps = Pick<UploadInfo, "status" | "error">;
+
+export const ImportProgress = ({ status, error }: ImportProgressProps) => {
+  switch (status) {
     case "error":
       return (
         <ImportProgressTooltip
-          label={fileUploadInfo.error!}
+          label={error ?? "Unknown error"}
           icon={ErrorIcon}
           color="red.500"
           aria-label="Error indicator"

--- a/typescript/web/src/components/import-button/import-images-modal/import-progress.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/import-progress.tsx
@@ -39,7 +39,7 @@ const getTooltipProps = ({
   status,
   error,
 }: ImportProgressProps): ImportProgressTooltipProps => {
-  if (status === "error") getErrorProps(error);
+  if (status === "error") return getErrorProps(error);
   return status === "uploaded" ? UPLOADED_PROPS : UPLOADING_PROPS;
 };
 
@@ -58,6 +58,7 @@ export const ImportProgressTooltip = ({
           fontSize="xl"
           color={color}
           aria-label={ariaLabel}
+          data-testid="import-progress-tooltip-icon"
         />
       </span>
     </Tooltip>

--- a/typescript/web/src/components/import-button/import-images-modal/import-progress.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/import-progress.tsx
@@ -1,4 +1,4 @@
-import { chakra, ChakraComponent, Tooltip } from "@chakra-ui/react";
+import { chakra, Tooltip, TooltipProps } from "@chakra-ui/react";
 import { IconType } from "react-icons/lib";
 import {
   RiCheckboxCircleFill,
@@ -7,28 +7,53 @@ import {
 } from "react-icons/ri";
 import { UploadInfo } from "./types";
 
-export const SucceedIcon = chakra(RiCheckboxCircleFill);
-export const LoadingIcon = chakra(RiContrastFill);
-export const ErrorIcon = chakra(RiErrorWarningFill);
+export type ImportProgressTooltipProps = Pick<
+  TooltipProps,
+  "label" | "color" | "aria-label"
+> & { icon: IconType };
 
-export type ImportProgressTooltipProps = {
-  label: string;
-  icon: ChakraComponent<IconType, {}>;
-  color: string;
-  "aria-label": string;
+const getErrorProps = (
+  error: string | undefined
+): ImportProgressTooltipProps => ({
+  label: error ?? "Unknown error",
+  icon: RiErrorWarningFill,
+  color: "red.500",
+  "aria-label": "Error indicator",
+});
+
+const UPLOADED_PROPS: ImportProgressTooltipProps = {
+  label: "Upload succeed",
+  icon: RiCheckboxCircleFill,
+  color: "green.500",
+  "aria-label": "Upload succeed",
+};
+
+const UPLOADING_PROPS: ImportProgressTooltipProps = {
+  label: "Upload in progress",
+  icon: RiContrastFill,
+  color: "gray.800",
+  "aria-label": "Loading indicator",
+};
+
+const getTooltipProps = ({
+  status,
+  error,
+}: ImportProgressProps): ImportProgressTooltipProps => {
+  if (status === "error") getErrorProps(error);
+  return status === "uploaded" ? UPLOADED_PROPS : UPLOADING_PROPS;
 };
 
 export const ImportProgressTooltip = ({
-  label,
   icon,
+  label,
   color,
   "aria-label": ariaLabel,
 }: ImportProgressTooltipProps) => {
-  const IconComponent = icon;
+  const Icon = chakra(icon);
   return (
     <Tooltip label={label} placement="left">
       <span>
-        <IconComponent
+        <Icon
           display="inline-block"
           fontSize="xl"
           color={color}
@@ -41,34 +66,6 @@ export const ImportProgressTooltip = ({
 
 export type ImportProgressProps = Pick<UploadInfo, "status" | "error">;
 
-export const ImportProgress = ({ status, error }: ImportProgressProps) => {
-  switch (status) {
-    case "error":
-      return (
-        <ImportProgressTooltip
-          label={error ?? "Unknown error"}
-          icon={ErrorIcon}
-          color="red.500"
-          aria-label="Error indicator"
-        />
-      );
-    case "uploaded":
-      return (
-        <ImportProgressTooltip
-          label="Upload succeed"
-          icon={SucceedIcon}
-          color="green.500"
-          aria-label="Upload succeed"
-        />
-      );
-    default:
-      return (
-        <ImportProgressTooltip
-          label="Upload in progress"
-          icon={LoadingIcon}
-          color="gray.800"
-          aria-label="Loading indicator"
-        />
-      );
-  }
-};
+export const ImportProgress = (props: ImportProgressProps) => (
+  <ImportProgressTooltip {...getTooltipProps(props)} />
+);

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/file-statuses.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/file-statuses.tsx
@@ -1,68 +1,131 @@
-import { RiImageLine, RiFile3Line } from "react-icons/ri";
+import { FileWithPath } from "react-dropzone";
+import {
+  RiImageLine,
+  RiBracesLine,
+  RiFolderZipLine,
+  RiFile3Line,
+} from "react-icons/ri";
 import { isEmpty } from "lodash/fp";
 import { Box, Text, Flex, useColorModeValue as mode } from "@chakra-ui/react";
 
-import { DroppedFile, UploadStatuses } from "../types";
+import { DroppedFile, UploadInfos, UploadInfo } from "../types";
 import { ImportProgress } from "../import-progress";
 import { ImportError } from "../import-error";
 
+const FileStatusIcon = ({
+  file,
+  hasErrors,
+}: {
+  file: FileWithPath;
+  hasErrors: boolean;
+}) => {
+  if (hasErrors) {
+    return <RiFile3Line />;
+  }
+  switch (file.type) {
+    case "application/json":
+      return <RiBracesLine />;
+    case "application/zip":
+      return <RiFolderZipLine />;
+    default:
+      return <RiImageLine />;
+  }
+};
+
+const FileStatus = ({
+  droppedFile,
+  index,
+  fileUploadInfo,
+}: {
+  droppedFile: DroppedFile;
+  index: number;
+  fileUploadInfo?: UploadInfo;
+}) => {
+  const datasetSkippedCrowdAnnotations =
+    fileUploadInfo?.datasetSkippedCrowdAnnotations;
+  return (
+    <>
+      <Flex
+        key={droppedFile.file.path}
+        w="100%"
+        alignItems="center"
+        p="2"
+        bg={index % 2 === 0 ? mode("gray.50", "gray.700") : "inherit"}
+      >
+        <Box flex={0} pr="2">
+          <FileStatusIcon
+            file={droppedFile.file}
+            hasErrors={!isEmpty(droppedFile.errors)}
+          />
+        </Box>
+        <Box
+          pr="2"
+          flexGrow={1}
+          flexShrink={1}
+          overflow="hidden"
+          textOverflow="ellipsis"
+          whiteSpace="nowrap"
+        >
+          {droppedFile.file.path}
+        </Box>
+        <Box
+          whiteSpace="nowrap"
+          flex={0}
+          color={mode("gray.400", "gray.600")}
+          fontSize="md"
+          textAlign="right"
+        >
+          {isEmpty(droppedFile.errors) ? (
+            <ImportProgress status={fileUploadInfo?.status || false} />
+          ) : (
+            <ImportError errors={droppedFile.errors} />
+          )}
+        </Box>
+      </Flex>
+      {datasetSkippedCrowdAnnotations && (
+        <Box
+          pr="2"
+          overflow="hidden"
+          textOverflow="ellipsis"
+          fontSize="xs"
+          color={mode("red.500", "red.300")}
+        >
+          {datasetSkippedCrowdAnnotations} RLE bitmap annotations were ignored.
+          Only polygon annotations are supported.
+        </Box>
+      )}
+    </>
+  );
+};
+
 export const FilesStatuses = ({
   files,
-  fileUploadStatuses,
+  fileUploadInfos,
 }: {
   files: Array<DroppedFile>;
-  fileUploadStatuses: UploadStatuses;
+  fileUploadInfos: UploadInfos;
 }) => (
   <Flex direction="column" height="100%">
     <Box p="2" bg={mode("gray.200", "gray.600")} borderTopRadius="md" w="100%">
       <Text>
         Completed{" "}
         {
-          Object.entries(fileUploadStatuses).filter(
-            (entry) => entry[1] === true
+          Object.entries(fileUploadInfos).filter(
+            (entry) => entry[1].status === true
           ).length
         }{" "}
         of {files.filter((file) => isEmpty(file.errors)).length} items
       </Text>
     </Box>
     <Flex direction="column" overflowY="auto" width="100%" height="100%">
-      {files.map(({ file, errors }, index) => (
-        <Flex
-          key={file.path}
-          w="100%"
-          alignItems="center"
-          p="2"
-          bg={index % 2 === 0 ? mode("gray.50", "gray.700") : "inherit"}
-        >
-          <Box flex={0} pr="2">
-            {isEmpty(errors) ? <RiImageLine /> : <RiFile3Line />}
-          </Box>
-          <Box
-            pr="2"
-            flexGrow={1}
-            flexShrink={1}
-            overflow="hidden"
-            textOverflow="ellipsis"
-            whiteSpace="nowrap"
-          >
-            {file.path}
-          </Box>
-          <Box
-            whiteSpace="nowrap"
-            flex={0}
-            color={mode("gray.400", "gray.600")}
-            fontSize="md"
-            textAlign="right"
-          >
-            {isEmpty(errors) ? (
-              <ImportProgress
-                status={fileUploadStatuses[file.path ?? file.name]}
-              />
-            ) : (
-              <ImportError errors={errors} />
-            )}
-          </Box>
-        </Flex>
+      {files.map((droppedFile, index) => (
+        <FileStatus
+          droppedFile={droppedFile}
+          index={index}
+          fileUploadInfo={
+            fileUploadInfos[droppedFile.file.path ?? droppedFile.file.name]
+          }
+        />
       ))}
     </Flex>
   </Flex>

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/file-statuses.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/file-statuses.tsx
@@ -8,14 +8,14 @@ import {
 import { isEmpty } from "lodash/fp";
 import { Box, Text, Flex, useColorModeValue as mode } from "@chakra-ui/react";
 
-import { DroppedFile, UploadInfoRecord, UploadInfo } from "../types";
+import { DroppedFile, FileUploadInfoRecord, FileUploadInfo } from "../types";
 import { ImportProgress } from "../import-progress";
 import { ImportError } from "../import-error";
 
 type FileStatusProps = {
   droppedFile: DroppedFile;
   index: number;
-  fileUploadInfo?: UploadInfo;
+  fileUploadInfo: FileUploadInfo;
 };
 
 const fileStatusIcon = (file: FileWithPath, hasErrors: boolean) => {
@@ -44,7 +44,7 @@ const ImportStatus = ({
     textAlign="right"
   >
     {isEmpty(droppedFile.errors) ? (
-      <ImportProgress status={fileUploadInfo?.status || false} />
+      <ImportProgress fileUploadInfo={fileUploadInfo} />
     ) : (
       <ImportError errors={droppedFile.errors} />
     )}
@@ -74,6 +74,7 @@ const Warnings = ({ warnings }: { warnings: string[] | undefined }) => (
           textOverflow="ellipsis"
           fontSize="xs"
           color={mode("red.500", "red.300")}
+          key={warning}
         >
           {warning}
         </Box>
@@ -119,7 +120,7 @@ export const FilesStatuses = ({
   fileUploadInfoRecord,
 }: {
   files: Array<DroppedFile>;
-  fileUploadInfoRecord: UploadInfoRecord;
+  fileUploadInfoRecord: FileUploadInfoRecord;
 }) => (
   <Flex direction="column" height="100%">
     <Box p="2" bg={mode("gray.200", "gray.600")} borderTopRadius="md" w="100%">
@@ -127,7 +128,7 @@ export const FilesStatuses = ({
         Completed{" "}
         {
           Object.entries(fileUploadInfoRecord).filter(
-            (entry) => entry[1].status === true
+            (entry) => entry[1].status === "uploaded"
           ).length
         }{" "}
         of {files.filter((file) => isEmpty(file.errors)).length} items
@@ -137,9 +138,12 @@ export const FilesStatuses = ({
       {files.map((droppedFile, index) => (
         <FileStatus
           droppedFile={droppedFile}
+          key={droppedFile.file.name}
           index={index}
           fileUploadInfo={
-            fileUploadInfoRecord[droppedFile.file.path ?? droppedFile.file.name]
+            fileUploadInfoRecord[
+              droppedFile.file.path ?? droppedFile.file.name
+            ] ?? { status: "pending" }
           }
         />
       ))}

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/file-statuses.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/file-statuses.tsx
@@ -41,8 +41,7 @@ const FileStatus = ({
   index: number;
   fileUploadInfo?: UploadInfo;
 }) => {
-  const datasetSkippedCrowdAnnotations =
-    fileUploadInfo?.datasetSkippedCrowdAnnotations;
+  const warnings = fileUploadInfo?.warnings;
   return (
     <>
       <Flex
@@ -82,18 +81,18 @@ const FileStatus = ({
           )}
         </Box>
       </Flex>
-      {datasetSkippedCrowdAnnotations && (
-        <Box
-          pr="2"
-          overflow="hidden"
-          textOverflow="ellipsis"
-          fontSize="xs"
-          color={mode("red.500", "red.300")}
-        >
-          {datasetSkippedCrowdAnnotations} RLE bitmap annotations were ignored.
-          Only polygon annotations are supported.
-        </Box>
-      )}
+      {warnings &&
+        warnings.map((warning) => (
+          <Box
+            pr="2"
+            overflow="hidden"
+            textOverflow="ellipsis"
+            fontSize="xs"
+            color={mode("red.500", "red.300")}
+          >
+            {warning}
+          </Box>
+        ))}
     </>
   );
 };

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/file-statuses.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/file-statuses.tsx
@@ -8,7 +8,7 @@ import {
 import { isEmpty } from "lodash/fp";
 import { Box, Text, Flex, useColorModeValue as mode } from "@chakra-ui/react";
 
-import { DroppedFile, UploadInfos, UploadInfo } from "../types";
+import { DroppedFile, UploadInfoRecord, UploadInfo } from "../types";
 import { ImportProgress } from "../import-progress";
 import { ImportError } from "../import-error";
 
@@ -116,17 +116,17 @@ const FileStatus = ({
 
 export const FilesStatuses = ({
   files,
-  fileUploadInfos,
+  fileUploadInfoRecord,
 }: {
   files: Array<DroppedFile>;
-  fileUploadInfos: UploadInfos;
+  fileUploadInfoRecord: UploadInfoRecord;
 }) => (
   <Flex direction="column" height="100%">
     <Box p="2" bg={mode("gray.200", "gray.600")} borderTopRadius="md" w="100%">
       <Text>
         Completed{" "}
         {
-          Object.entries(fileUploadInfos).filter(
+          Object.entries(fileUploadInfoRecord).filter(
             (entry) => entry[1].status === true
           ).length
         }{" "}
@@ -139,7 +139,7 @@ export const FilesStatuses = ({
           droppedFile={droppedFile}
           index={index}
           fileUploadInfo={
-            fileUploadInfos[droppedFile.file.path ?? droppedFile.file.name]
+            fileUploadInfoRecord[droppedFile.file.path ?? droppedFile.file.name]
           }
         />
       ))}

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/file-statuses.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/file-statuses.tsx
@@ -12,36 +12,85 @@ import { DroppedFile, UploadInfos, UploadInfo } from "../types";
 import { ImportProgress } from "../import-progress";
 import { ImportError } from "../import-error";
 
-const FileStatusIcon = ({
-  file,
-  hasErrors,
-}: {
-  file: FileWithPath;
-  hasErrors: boolean;
-}) => {
+type FileStatusProps = {
+  droppedFile: DroppedFile;
+  index: number;
+  fileUploadInfo?: UploadInfo;
+};
+
+const fileStatusIcon = (file: FileWithPath, hasErrors: boolean) => {
   if (hasErrors) {
-    return <RiFile3Line />;
+    return RiFile3Line;
   }
   switch (file.type) {
     case "application/json":
-      return <RiBracesLine />;
+      return RiBracesLine;
     case "application/zip":
-      return <RiFolderZipLine />;
+      return RiFolderZipLine;
     default:
-      return <RiImageLine />;
+      return RiImageLine;
   }
 };
+
+const ImportStatus = ({
+  droppedFile,
+  fileUploadInfo,
+}: Omit<FileStatusProps, "index">) => (
+  <Box
+    whiteSpace="nowrap"
+    flex={0}
+    color={mode("gray.400", "gray.600")}
+    fontSize="md"
+    textAlign="right"
+  >
+    {isEmpty(droppedFile.errors) ? (
+      <ImportProgress status={fileUploadInfo?.status || false} />
+    ) : (
+      <ImportError errors={droppedFile.errors} />
+    )}
+  </Box>
+);
+
+const FilePath = ({ droppedFile }: Pick<FileStatusProps, "droppedFile">) => (
+  <Box
+    pr="2"
+    flexGrow={1}
+    flexShrink={1}
+    overflow="hidden"
+    textOverflow="ellipsis"
+    whiteSpace="nowrap"
+  >
+    {droppedFile.file.path}
+  </Box>
+);
+
+const Warnings = ({ warnings }: { warnings: string[] | undefined }) => (
+  <>
+    {warnings &&
+      warnings.map((warning) => (
+        <Box
+          pr="2"
+          overflow="hidden"
+          textOverflow="ellipsis"
+          fontSize="xs"
+          color={mode("red.500", "red.300")}
+        >
+          {warning}
+        </Box>
+      ))}
+  </>
+);
 
 const FileStatus = ({
   droppedFile,
   index,
   fileUploadInfo,
-}: {
-  droppedFile: DroppedFile;
-  index: number;
-  fileUploadInfo?: UploadInfo;
-}) => {
+}: FileStatusProps) => {
   const warnings = fileUploadInfo?.warnings;
+  const FileStatusIcon = fileStatusIcon(
+    droppedFile.file,
+    !isEmpty(droppedFile.errors)
+  );
   return (
     <>
       <Flex
@@ -52,47 +101,15 @@ const FileStatus = ({
         bg={index % 2 === 0 ? mode("gray.50", "gray.700") : "inherit"}
       >
         <Box flex={0} pr="2">
-          <FileStatusIcon
-            file={droppedFile.file}
-            hasErrors={!isEmpty(droppedFile.errors)}
-          />
+          <FileStatusIcon />
         </Box>
-        <Box
-          pr="2"
-          flexGrow={1}
-          flexShrink={1}
-          overflow="hidden"
-          textOverflow="ellipsis"
-          whiteSpace="nowrap"
-        >
-          {droppedFile.file.path}
-        </Box>
-        <Box
-          whiteSpace="nowrap"
-          flex={0}
-          color={mode("gray.400", "gray.600")}
-          fontSize="md"
-          textAlign="right"
-        >
-          {isEmpty(droppedFile.errors) ? (
-            <ImportProgress status={fileUploadInfo?.status || false} />
-          ) : (
-            <ImportError errors={droppedFile.errors} />
-          )}
-        </Box>
+        <FilePath droppedFile={droppedFile} />
+        <ImportStatus
+          droppedFile={droppedFile}
+          fileUploadInfo={fileUploadInfo}
+        />
       </Flex>
-      {warnings &&
-        warnings.map((warning) => (
-          <Box
-            pr="2"
-            overflow="hidden"
-            textOverflow="ellipsis"
-            fontSize="xs"
-            color={mode("red.500", "red.300")}
-          >
-            {warning}
-          </Box>
-        ))}
+      <Warnings warnings={warnings} />
     </>
   );
 };

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/import-datasets.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/import-datasets.tsx
@@ -4,7 +4,7 @@ import mime from "mime-types";
 
 import Bluebird from "bluebird";
 import { uploadFile } from "../../../../../utils/upload-file";
-import { DroppedFile, SetUploadInfos } from "../../types";
+import { DroppedFile, SetUploadInfoRecord } from "../../types";
 
 import { CONCURRENCY } from "../../constants";
 import { ExportFormat } from "../../../../../graphql-types/globalTypes";
@@ -74,13 +74,13 @@ export const importDatasets = async ({
   datasetId,
   workspaceId,
   apolloClient,
-  setFileUploadInfos,
+  setFileUploadInfoRecord,
 }: {
   datasets: DroppedFile[];
   datasetId: string;
   workspaceId: string;
   apolloClient: ApolloClient<object>;
-  setFileUploadInfos: SetUploadInfos;
+  setFileUploadInfoRecord: SetUploadInfoRecord;
 }) => {
   return await Bluebird.Promise.map(
     datasets,
@@ -92,8 +92,8 @@ export const importDatasets = async ({
         apolloClient,
       });
 
-      setFileUploadInfos((infos) => ({
-        ...infos,
+      setFileUploadInfoRecord((info) => ({
+        ...info,
         [file.name ?? file.path]: {
           status: true,
           warnings,

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/import-datasets.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/import-datasets.tsx
@@ -95,7 +95,7 @@ export const importDatasets = async ({
       setFileUploadInfoRecord((info) => ({
         ...info,
         [file.name ?? file.path]: {
-          status: true,
+          status: "uploaded",
           warnings,
         },
       }));

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/import-images.ts
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/import-images.ts
@@ -1,14 +1,11 @@
-/* eslint-disable no-underscore-dangle */
 import { ApolloClient, gql } from "@apollo/client";
-import { v4 as uuidv4 } from "uuid";
 import Bluebird from "bluebird";
-import mime from "mime-types";
 import chunk from "lodash/fp/chunk";
-
+import mime from "mime-types";
+import { v4 as uuidv4 } from "uuid";
 import { uploadFile } from "../../../../../utils/upload-file";
-import { DroppedFile, SetUploadInfoRecord } from "../../types";
-
 import { BATCH_SIZE, CONCURRENCY } from "../../constants";
+import { DroppedFile, SetUploadInfo } from "../../types";
 
 export const CREATE_MANY_IMAGES_MUTATION = gql`
   mutation CreateManyImagesInModalMutation(
@@ -58,19 +55,21 @@ const uploadBatchOfImages = async ({
   );
 };
 
+export type ImportImagesOptions = {
+  images: DroppedFile[];
+  workspaceId: string;
+  datasetId: string;
+  apolloClient: ApolloClient<object>;
+  setUploadInfo: SetUploadInfo;
+};
+
 export const importImages = async ({
   images,
   workspaceId,
   datasetId,
   apolloClient,
-  setFileUploadInfoRecord,
-}: {
-  images: DroppedFile[];
-  workspaceId: string;
-  datasetId: string;
-  apolloClient: ApolloClient<object>;
-  setFileUploadInfoRecord: SetUploadInfoRecord;
-}) => {
+  setUploadInfo,
+}: ImportImagesOptions) => {
   const firstUploadDate = new Date();
   const batches = chunk(BATCH_SIZE, images);
 
@@ -92,14 +91,14 @@ export const importImages = async ({
           variables: { images: imagesToCreate, datasetId },
         });
 
-        setFileUploadInfoRecord((oldInfo) => ({
+        setUploadInfo((oldInfo) => ({
           ...oldInfo,
           ...Object.fromEntries(
             imagesToCreate.map((image) => [image.name, { status: "uploaded" }])
           ),
         }));
       } catch (error) {
-        setFileUploadInfoRecord((oldInfo) => ({
+        setUploadInfo((oldInfo) => ({
           ...oldInfo,
           ...Object.fromEntries(
             batch.map(({ file }) => [

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/import-images.ts
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/import-images.ts
@@ -95,14 +95,20 @@ export const importImages = async ({
         setFileUploadInfos((oldInfos) => ({
           ...oldInfos,
           ...Object.fromEntries(
-            imagesToCreate.map((image) => [image.name, { status: true }])
+            imagesToCreate.map((image) => [
+              image.name,
+              { status: true, warnings: [] },
+            ])
           ),
         }));
       } catch (error) {
         setFileUploadInfos((oldInfos) => ({
           ...oldInfos,
           ...Object.fromEntries(
-            batch.map(({ file }) => [file.name, { status: error?.message }])
+            batch.map(({ file }) => [
+              file.name,
+              { status: error?.message, warnings: [] },
+            ])
           ),
         }));
       }

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/import-images.ts
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/import-images.ts
@@ -6,7 +6,7 @@ import mime from "mime-types";
 import chunk from "lodash/fp/chunk";
 
 import { uploadFile } from "../../../../../utils/upload-file";
-import { DroppedFile, SetUploadInfos } from "../../types";
+import { DroppedFile, SetUploadInfoRecord } from "../../types";
 
 import { BATCH_SIZE, CONCURRENCY } from "../../constants";
 
@@ -63,13 +63,13 @@ export const importImages = async ({
   workspaceId,
   datasetId,
   apolloClient,
-  setFileUploadInfos,
+  setFileUploadInfoRecord,
 }: {
   images: DroppedFile[];
   workspaceId: string;
   datasetId: string;
   apolloClient: ApolloClient<object>;
-  setFileUploadInfos: SetUploadInfos;
+  setFileUploadInfoRecord: SetUploadInfoRecord;
 }) => {
   const firstUploadDate = new Date();
   const batches = chunk(BATCH_SIZE, images);
@@ -92,8 +92,8 @@ export const importImages = async ({
           variables: { images: imagesToCreate, datasetId },
         });
 
-        setFileUploadInfos((oldInfos) => ({
-          ...oldInfos,
+        setFileUploadInfoRecord((oldInfo) => ({
+          ...oldInfo,
           ...Object.fromEntries(
             imagesToCreate.map((image) => [
               image.name,
@@ -102,8 +102,8 @@ export const importImages = async ({
           ),
         }));
       } catch (error) {
-        setFileUploadInfos((oldInfos) => ({
-          ...oldInfos,
+        setFileUploadInfoRecord((oldInfo) => ({
+          ...oldInfo,
           ...Object.fromEntries(
             batch.map(({ file }) => [
               file.name,

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/import-images.ts
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/import-images.ts
@@ -6,7 +6,7 @@ import mime from "mime-types";
 import chunk from "lodash/fp/chunk";
 
 import { uploadFile } from "../../../../../utils/upload-file";
-import { DroppedFile, SetUploadStatuses } from "../../types";
+import { DroppedFile, SetUploadInfos } from "../../types";
 
 import { BATCH_SIZE, CONCURRENCY } from "../../constants";
 
@@ -63,13 +63,13 @@ export const importImages = async ({
   workspaceId,
   datasetId,
   apolloClient,
-  setFileUploadStatuses,
+  setFileUploadInfos,
 }: {
   images: DroppedFile[];
   workspaceId: string;
   datasetId: string;
   apolloClient: ApolloClient<object>;
-  setFileUploadStatuses: SetUploadStatuses;
+  setFileUploadInfos: SetUploadInfos;
 }) => {
   const firstUploadDate = new Date();
   const batches = chunk(BATCH_SIZE, images);
@@ -92,17 +92,17 @@ export const importImages = async ({
           variables: { images: imagesToCreate, datasetId },
         });
 
-        setFileUploadStatuses((oldStatuses) => ({
-          ...oldStatuses,
+        setFileUploadInfos((oldInfos) => ({
+          ...oldInfos,
           ...Object.fromEntries(
-            imagesToCreate.map((image) => [image.name, true])
+            imagesToCreate.map((image) => [image.name, { status: true }])
           ),
         }));
       } catch (error) {
-        setFileUploadStatuses((oldStatuses) => ({
-          ...oldStatuses,
+        setFileUploadInfos((oldInfos) => ({
+          ...oldInfos,
           ...Object.fromEntries(
-            batch.map(({ file }) => [file.name, error?.message])
+            batch.map(({ file }) => [file.name, { status: error?.message }])
           ),
         }));
       }

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/import-images.ts
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/import-images.ts
@@ -95,10 +95,7 @@ export const importImages = async ({
         setFileUploadInfoRecord((oldInfo) => ({
           ...oldInfo,
           ...Object.fromEntries(
-            imagesToCreate.map((image) => [
-              image.name,
-              { status: true, warnings: [] },
-            ])
+            imagesToCreate.map((image) => [image.name, { status: "uploaded" }])
           ),
         }));
       } catch (error) {
@@ -107,7 +104,7 @@ export const importImages = async ({
           ...Object.fromEntries(
             batch.map(({ file }) => [
               file.name,
-              { status: error?.message, warnings: [] },
+              { status: "error", error: error?.message },
             ])
           ),
         }));

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/index.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/index.tsx
@@ -6,19 +6,19 @@ import partition from "lodash/fp/partition";
 
 import { importImages } from "./import-images";
 import { importDatasets } from "./import-datasets";
-import { DroppedFile, SetUploadStatuses } from "../../types";
+import { DroppedFile, SetUploadInfos } from "../../types";
 
 export const importDroppedFiles = async ({
   files,
   workspaceId,
   datasetId,
-  setFileUploadStatuses,
+  setFileUploadInfos,
   apolloClient,
 }: {
   files: DroppedFile[];
   workspaceId: string;
   datasetId: string;
-  setFileUploadStatuses: SetUploadStatuses;
+  setFileUploadInfos: SetUploadInfos;
   apolloClient: ApolloClient<object>;
 }) => {
   const acceptedFiles = files.filter((file) => isEmpty(file.errors));
@@ -35,7 +35,7 @@ export const importDroppedFiles = async ({
     workspaceId,
     datasetId,
     apolloClient,
-    setFileUploadStatuses,
+    setFileUploadInfos,
   });
 
   await importDatasets({
@@ -43,6 +43,6 @@ export const importDroppedFiles = async ({
     datasetId,
     workspaceId,
     apolloClient,
-    setFileUploadStatuses,
+    setFileUploadInfos,
   });
 };

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/index.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/index.tsx
@@ -6,19 +6,19 @@ import partition from "lodash/fp/partition";
 
 import { importImages } from "./import-images";
 import { importDatasets } from "./import-datasets";
-import { DroppedFile, SetUploadInfos } from "../../types";
+import { DroppedFile, SetUploadInfoRecord } from "../../types";
 
 export const importDroppedFiles = async ({
   files,
   workspaceId,
   datasetId,
-  setFileUploadInfos,
+  setFileUploadInfoRecord,
   apolloClient,
 }: {
   files: DroppedFile[];
   workspaceId: string;
   datasetId: string;
-  setFileUploadInfos: SetUploadInfos;
+  setFileUploadInfoRecord: SetUploadInfoRecord;
   apolloClient: ApolloClient<object>;
 }) => {
   const acceptedFiles = files.filter((file) => isEmpty(file.errors));
@@ -35,7 +35,7 @@ export const importDroppedFiles = async ({
     workspaceId,
     datasetId,
     apolloClient,
-    setFileUploadInfos,
+    setFileUploadInfoRecord,
   });
 
   await importDatasets({
@@ -43,6 +43,6 @@ export const importDroppedFiles = async ({
     datasetId,
     workspaceId,
     apolloClient,
-    setFileUploadInfos,
+    setFileUploadInfoRecord,
   });
 };

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/index.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/import-dropped-files/index.tsx
@@ -6,19 +6,19 @@ import partition from "lodash/fp/partition";
 
 import { importImages } from "./import-images";
 import { importDatasets } from "./import-datasets";
-import { DroppedFile, SetUploadInfoRecord } from "../../types";
+import { DroppedFile, SetUploadInfo } from "../../types";
 
 export const importDroppedFiles = async ({
   files,
   workspaceId,
   datasetId,
-  setFileUploadInfoRecord,
+  setUploadInfo,
   apolloClient,
 }: {
   files: DroppedFile[];
   workspaceId: string;
   datasetId: string;
-  setFileUploadInfoRecord: SetUploadInfoRecord;
+  setUploadInfo: SetUploadInfo;
   apolloClient: ApolloClient<object>;
 }) => {
   const acceptedFiles = files.filter((file) => isEmpty(file.errors));
@@ -35,7 +35,7 @@ export const importDroppedFiles = async ({
     workspaceId,
     datasetId,
     apolloClient,
-    setFileUploadInfoRecord,
+    setUploadInfo,
   });
 
   await importDatasets({
@@ -43,6 +43,6 @@ export const importDroppedFiles = async ({
     datasetId,
     workspaceId,
     apolloClient,
-    setFileUploadInfoRecord,
+    setUploadInfo,
   });
 };

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/modal-dropzone.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/modal-dropzone.tsx
@@ -15,7 +15,7 @@ import {
 import { useDataset, useWorkspace } from "../../../../hooks";
 import { flushPaginatedImagesCache } from "../../../dataset-images-list";
 import { GET_DATASET_BY_SLUG_QUERY } from "../../../datasets/datasets.query";
-import { DroppedFile, UploadStatuses } from "../types";
+import { DroppedFile, UploadInfos } from "../types";
 import { Dropzone } from "./dropzone";
 import { FilesStatuses } from "./file-statuses";
 import { importDroppedFiles } from "./import-dropped-files";
@@ -38,9 +38,7 @@ export const ImportImagesModalDropzone = ({
    * internal state
    */
   const [files, setFiles] = useState<Array<DroppedFile>>([]);
-  const [fileUploadStatuses, setFileUploadStatuses] = useState<UploadStatuses>(
-    {}
-  );
+  const [fileUploadInfos, setFileUploadInfos] = useState<UploadInfos>({});
 
   const { data: datasetResult } = useQuery<
     GetDatasetBySlugQuery,
@@ -64,7 +62,7 @@ export const ImportImagesModalDropzone = ({
         files: filesToImport,
         workspaceId,
         datasetId,
-        setFileUploadStatuses,
+        setFileUploadInfos,
         apolloClient,
       });
       onUploadEnd();
@@ -72,7 +70,7 @@ export const ImportImagesModalDropzone = ({
     [
       workspaceId,
       datasetId,
-      setFileUploadStatuses,
+      setFileUploadInfos,
       apolloClient,
       onUploadStart,
       onUploadEnd,
@@ -115,10 +113,7 @@ export const ImportImagesModalDropzone = ({
         {isEmpty(files) ? (
           <Dropzone onDropEnd={setFiles} />
         ) : (
-          <FilesStatuses
-            files={files}
-            fileUploadStatuses={fileUploadStatuses}
-          />
+          <FilesStatuses files={files} fileUploadInfos={fileUploadInfos} />
         )}
       </ModalBody>
     </>

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/modal-dropzone.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/modal-dropzone.tsx
@@ -15,7 +15,7 @@ import {
 import { useDataset, useWorkspace } from "../../../../hooks";
 import { flushPaginatedImagesCache } from "../../../dataset-images-list";
 import { GET_DATASET_BY_SLUG_QUERY } from "../../../datasets/datasets.query";
-import { DroppedFile, UploadInfoRecord } from "../types";
+import { DroppedFile, FileUploadInfoRecord } from "../types";
 import { Dropzone } from "./dropzone";
 import { FilesStatuses } from "./file-statuses";
 import { importDroppedFiles } from "./import-dropped-files";
@@ -39,7 +39,7 @@ export const ImportImagesModalDropzone = ({
    */
   const [files, setFiles] = useState<Array<DroppedFile>>([]);
   const [fileUploadInfoRecord, setFileUploadInfoRecord] =
-    useState<UploadInfoRecord>({});
+    useState<FileUploadInfoRecord>({});
 
   const { data: datasetResult } = useQuery<
     GetDatasetBySlugQuery,

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/modal-dropzone.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/modal-dropzone.tsx
@@ -15,7 +15,7 @@ import {
 import { useDataset, useWorkspace } from "../../../../hooks";
 import { flushPaginatedImagesCache } from "../../../dataset-images-list";
 import { GET_DATASET_BY_SLUG_QUERY } from "../../../datasets/datasets.query";
-import { DroppedFile, UploadInfos } from "../types";
+import { DroppedFile, UploadInfoRecord } from "../types";
 import { Dropzone } from "./dropzone";
 import { FilesStatuses } from "./file-statuses";
 import { importDroppedFiles } from "./import-dropped-files";
@@ -38,7 +38,8 @@ export const ImportImagesModalDropzone = ({
    * internal state
    */
   const [files, setFiles] = useState<Array<DroppedFile>>([]);
-  const [fileUploadInfos, setFileUploadInfos] = useState<UploadInfos>({});
+  const [fileUploadInfoRecord, setFileUploadInfoRecord] =
+    useState<UploadInfoRecord>({});
 
   const { data: datasetResult } = useQuery<
     GetDatasetBySlugQuery,
@@ -62,7 +63,7 @@ export const ImportImagesModalDropzone = ({
         files: filesToImport,
         workspaceId,
         datasetId,
-        setFileUploadInfos,
+        setFileUploadInfoRecord,
         apolloClient,
       });
       onUploadEnd();
@@ -70,7 +71,7 @@ export const ImportImagesModalDropzone = ({
     [
       workspaceId,
       datasetId,
-      setFileUploadInfos,
+      setFileUploadInfoRecord,
       apolloClient,
       onUploadStart,
       onUploadEnd,
@@ -113,7 +114,10 @@ export const ImportImagesModalDropzone = ({
         {isEmpty(files) ? (
           <Dropzone onDropEnd={setFiles} />
         ) : (
-          <FilesStatuses files={files} fileUploadInfos={fileUploadInfos} />
+          <FilesStatuses
+            files={files}
+            fileUploadInfoRecord={fileUploadInfoRecord}
+          />
         )}
       </ModalBody>
     </>

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/modal-dropzone.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/modal-dropzone.tsx
@@ -15,7 +15,7 @@ import {
 import { useDataset, useWorkspace } from "../../../../hooks";
 import { flushPaginatedImagesCache } from "../../../dataset-images-list";
 import { GET_DATASET_BY_SLUG_QUERY } from "../../../datasets/datasets.query";
-import { DroppedFile, FileUploadInfoRecord } from "../types";
+import { DroppedFile, UploadInfoRecord } from "../types";
 import { Dropzone } from "./dropzone";
 import { FilesStatuses } from "./file-statuses";
 import { importDroppedFiles } from "./import-dropped-files";
@@ -38,8 +38,7 @@ export const ImportImagesModalDropzone = ({
    * internal state
    */
   const [files, setFiles] = useState<Array<DroppedFile>>([]);
-  const [fileUploadInfoRecord, setFileUploadInfoRecord] =
-    useState<FileUploadInfoRecord>({});
+  const [uploadInfo, setUploadInfo] = useState<UploadInfoRecord>({});
 
   const { data: datasetResult } = useQuery<
     GetDatasetBySlugQuery,
@@ -63,7 +62,7 @@ export const ImportImagesModalDropzone = ({
         files: filesToImport,
         workspaceId,
         datasetId,
-        setFileUploadInfoRecord,
+        setUploadInfo,
         apolloClient,
       });
       onUploadEnd();
@@ -71,7 +70,7 @@ export const ImportImagesModalDropzone = ({
     [
       workspaceId,
       datasetId,
-      setFileUploadInfoRecord,
+      setUploadInfo,
       apolloClient,
       onUploadStart,
       onUploadEnd,
@@ -114,10 +113,7 @@ export const ImportImagesModalDropzone = ({
         {isEmpty(files) ? (
           <Dropzone onDropEnd={setFiles} />
         ) : (
-          <FilesStatuses
-            files={files}
-            fileUploadInfoRecord={fileUploadInfoRecord}
-          />
+          <FilesStatuses files={files} uploadInfo={uploadInfo} />
         )}
       </ModalBody>
     </>

--- a/typescript/web/src/components/import-button/import-images-modal/modal-url-list/import-urls.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-url-list/import-urls.tsx
@@ -2,7 +2,7 @@ import isEmpty from "lodash/fp/isEmpty";
 import chunk from "lodash/fp/chunk";
 import { ApolloClient, gql } from "@apollo/client";
 import Bluebird from "bluebird";
-import { DroppedUrl, SetUploadStatuses } from "../types";
+import { DroppedUrl, SetUploadInfoRecord } from "../types";
 
 import { BATCH_SIZE, CONCURRENCY } from "../constants";
 
@@ -26,7 +26,7 @@ export const importUrls = async ({
   urls: DroppedUrl[];
   apolloClient: ApolloClient<object>;
   datasetId: any;
-  setUploadStatuses: SetUploadStatuses;
+  setUploadStatuses: SetUploadInfoRecord;
 }) => {
   const now = new Date();
 
@@ -56,7 +56,10 @@ export const importUrls = async ({
         setUploadStatuses((oldStatuses) => ({
           ...oldStatuses,
           ...Object.fromEntries(
-            imagesToCreate.map(({ externalUrl }) => [externalUrl, true])
+            imagesToCreate.map(({ externalUrl }) => [
+              externalUrl,
+              { status: "uploaded" },
+            ])
           ),
         }));
       } catch (error) {
@@ -65,7 +68,7 @@ export const importUrls = async ({
           ...Object.fromEntries(
             imagesToCreate.map(({ externalUrl }) => [
               externalUrl,
-              error?.message,
+              { status: "error", error: error?.message },
             ])
           ),
         }));

--- a/typescript/web/src/components/import-button/import-images-modal/modal-url-list/import-urls.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-url-list/import-urls.tsx
@@ -2,7 +2,7 @@ import isEmpty from "lodash/fp/isEmpty";
 import chunk from "lodash/fp/chunk";
 import { ApolloClient, gql } from "@apollo/client";
 import Bluebird from "bluebird";
-import { DroppedUrl, SetUploadInfoRecord } from "../types";
+import { DroppedUrl, SetUploadInfo } from "../types";
 
 import { BATCH_SIZE, CONCURRENCY } from "../constants";
 
@@ -17,17 +17,19 @@ export const CREATE_MANY_IMAGES_MUTATION = gql`
   }
 `;
 
+export type ImportUrlsOptions = {
+  urls: DroppedUrl[];
+  apolloClient: ApolloClient<object>;
+  datasetId: any;
+  setUploadInfo: SetUploadInfo;
+};
+
 export const importUrls = async ({
   urls,
   apolloClient,
   datasetId,
-  setUploadStatuses,
-}: {
-  urls: DroppedUrl[];
-  apolloClient: ApolloClient<object>;
-  datasetId: any;
-  setUploadStatuses: SetUploadInfoRecord;
-}) => {
+  setUploadInfo,
+}: ImportUrlsOptions) => {
   const now = new Date();
 
   const validUrls = urls.filter((url) => isEmpty(url.errors));
@@ -53,7 +55,7 @@ export const importUrls = async ({
           variables: { images: imagesToCreate, datasetId },
         });
 
-        setUploadStatuses((oldStatuses) => ({
+        setUploadInfo((oldStatuses) => ({
           ...oldStatuses,
           ...Object.fromEntries(
             imagesToCreate.map(({ externalUrl }) => [
@@ -63,7 +65,7 @@ export const importUrls = async ({
           ),
         }));
       } catch (error) {
-        setUploadStatuses((oldStatuses) => ({
+        setUploadInfo((oldStatuses) => ({
           ...oldStatuses,
           ...Object.fromEntries(
             imagesToCreate.map(({ externalUrl }) => [

--- a/typescript/web/src/components/import-button/import-images-modal/modal-url-list/modal-url-list.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-url-list/modal-url-list.tsx
@@ -14,7 +14,7 @@ import {
 } from "../../../../graphql-types/GetDatasetBySlugQuery";
 import { GET_DATASET_BY_SLUG_QUERY } from "../../../datasets/datasets.query";
 import { useDataset, useWorkspace } from "../../../../hooks";
-import { DroppedUrl, FileUploadInfoRecord } from "../types";
+import { DroppedUrl, UploadInfoRecord } from "../types";
 import { importUrls } from "./import-urls";
 import { UrlList } from "./url-list";
 import { UrlStatuses } from "./url-statuses";
@@ -39,9 +39,7 @@ export const ImportImagesModalUrlList = ({
    * internal state
    */
   const [urls, setUrls] = useState<Array<DroppedUrl>>([]);
-  const [uploadStatuses, setUploadStatuses] = useState<FileUploadInfoRecord>(
-    {}
-  );
+  const [uploadInfo, setUploadInfo] = useState<UploadInfoRecord>({});
 
   const { data: datasetResult } = useQuery<
     GetDatasetBySlugQuery,
@@ -61,12 +59,12 @@ export const ImportImagesModalUrlList = ({
         urls: urlsToImport,
         apolloClient,
         datasetId,
-        setUploadStatuses,
+        setUploadInfo,
       });
 
       onUploadEnd();
     },
-    [apolloClient, datasetId, setUploadStatuses, onUploadStart, onUploadEnd]
+    [apolloClient, datasetId, setUploadInfo, onUploadStart, onUploadEnd]
   );
 
   useEffect(() => {
@@ -110,7 +108,7 @@ export const ImportImagesModalUrlList = ({
         {isEmpty(urls) ? (
           <UrlList onDropEnd={setUrls} />
         ) : (
-          <UrlStatuses urls={urls} fileUploadInfoRecord={uploadStatuses} />
+          <UrlStatuses urls={urls} uploadInfo={uploadInfo} />
         )}
       </ModalBody>
     </>

--- a/typescript/web/src/components/import-button/import-images-modal/modal-url-list/modal-url-list.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-url-list/modal-url-list.tsx
@@ -14,7 +14,7 @@ import {
 } from "../../../../graphql-types/GetDatasetBySlugQuery";
 import { GET_DATASET_BY_SLUG_QUERY } from "../../../datasets/datasets.query";
 import { useDataset, useWorkspace } from "../../../../hooks";
-import { DroppedUrl, UploadStatuses } from "../types";
+import { DroppedUrl, FileUploadInfoRecord } from "../types";
 import { importUrls } from "./import-urls";
 import { UrlList } from "./url-list";
 import { UrlStatuses } from "./url-statuses";
@@ -39,7 +39,9 @@ export const ImportImagesModalUrlList = ({
    * internal state
    */
   const [urls, setUrls] = useState<Array<DroppedUrl>>([]);
-  const [uploadStatuses, setUploadStatuses] = useState<UploadStatuses>({});
+  const [uploadStatuses, setUploadStatuses] = useState<FileUploadInfoRecord>(
+    {}
+  );
 
   const { data: datasetResult } = useQuery<
     GetDatasetBySlugQuery,
@@ -108,7 +110,7 @@ export const ImportImagesModalUrlList = ({
         {isEmpty(urls) ? (
           <UrlList onDropEnd={setUrls} />
         ) : (
-          <UrlStatuses urls={urls} uploadStatuses={uploadStatuses} />
+          <UrlStatuses urls={urls} fileUploadInfoRecord={uploadStatuses} />
         )}
       </ModalBody>
     </>

--- a/typescript/web/src/components/import-button/import-images-modal/modal-url-list/url-statuses.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-url-list/url-statuses.tsx
@@ -2,23 +2,22 @@ import { RiImageLine, RiFile3Line } from "react-icons/ri";
 import { isEmpty } from "lodash/fp";
 import { Box, Text, Flex, useColorModeValue as mode } from "@chakra-ui/react";
 
-import { DroppedUrl, FileUploadInfoRecord } from "../types";
+import { DroppedUrl, UploadInfoRecord } from "../types";
 import { ImportProgress } from "../import-progress";
 import { ImportError } from "../import-error";
 
-export const UrlStatuses = ({
-  urls,
-  fileUploadInfoRecord,
-}: {
+export type UrlStatusesProps = {
   urls: Array<DroppedUrl>;
-  fileUploadInfoRecord: FileUploadInfoRecord;
-}) => (
+  uploadInfo: UploadInfoRecord;
+};
+
+export const UrlStatuses = ({ urls, uploadInfo }: UrlStatusesProps) => (
   <Flex direction="column" height="100%">
     <Box p="2" bg={mode("gray.200", "gray.600")} borderTopRadius="md" w="100%">
       <Text>
         Completed{" "}
         {
-          Object.entries(fileUploadInfoRecord).filter(
+          Object.entries(uploadInfo).filter(
             (entry) => entry[1].status === "uploaded"
           ).length
         }{" "}
@@ -55,11 +54,7 @@ export const UrlStatuses = ({
             textAlign="right"
           >
             {isEmpty(errors) ? (
-              <ImportProgress
-                fileUploadInfo={
-                  fileUploadInfoRecord[url] ?? { status: "pending" }
-                }
-              />
+              <ImportProgress {...(uploadInfo[url] ?? { status: "loading" })} />
             ) : (
               <ImportError errors={errors} />
             )}

--- a/typescript/web/src/components/import-button/import-images-modal/modal-url-list/url-statuses.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-url-list/url-statuses.tsx
@@ -2,24 +2,25 @@ import { RiImageLine, RiFile3Line } from "react-icons/ri";
 import { isEmpty } from "lodash/fp";
 import { Box, Text, Flex, useColorModeValue as mode } from "@chakra-ui/react";
 
-import { DroppedUrl, UploadStatuses } from "../types";
+import { DroppedUrl, FileUploadInfoRecord } from "../types";
 import { ImportProgress } from "../import-progress";
 import { ImportError } from "../import-error";
 
 export const UrlStatuses = ({
   urls,
-  uploadStatuses,
+  fileUploadInfoRecord,
 }: {
   urls: Array<DroppedUrl>;
-  uploadStatuses: UploadStatuses;
+  fileUploadInfoRecord: FileUploadInfoRecord;
 }) => (
   <Flex direction="column" height="100%">
     <Box p="2" bg={mode("gray.200", "gray.600")} borderTopRadius="md" w="100%">
       <Text>
         Completed{" "}
         {
-          Object.entries(uploadStatuses).filter((entry) => entry[1] === true)
-            .length
+          Object.entries(fileUploadInfoRecord).filter(
+            (entry) => entry[1].status === "uploaded"
+          ).length
         }{" "}
         of {urls.filter((url) => isEmpty(url.errors)).length} items
       </Text>
@@ -54,7 +55,11 @@ export const UrlStatuses = ({
             textAlign="right"
           >
             {isEmpty(errors) ? (
-              <ImportProgress status={uploadStatuses[url]} />
+              <ImportProgress
+                fileUploadInfo={
+                  fileUploadInfoRecord[url] ?? { status: "pending" }
+                }
+              />
             ) : (
               <ImportError errors={errors} />
             )}

--- a/typescript/web/src/components/import-button/import-images-modal/types.ts
+++ b/typescript/web/src/components/import-button/import-images-modal/types.ts
@@ -24,7 +24,14 @@ export type DroppedUrl = {
  */
 export type UploadStatuses = Record<string, boolean | string>;
 
+export type UploadInfo = {
+  status: boolean | string;
+  datasetSkippedCrowdAnnotations?: number;
+};
+export type UploadInfos = Record<string, UploadInfo>;
+
 /**
  * Setter function for the upload statuses
  */
 export type SetUploadStatuses = SetState<UploadStatuses>;
+export type SetUploadInfos = SetState<UploadInfos>;

--- a/typescript/web/src/components/import-button/import-images-modal/types.ts
+++ b/typescript/web/src/components/import-button/import-images-modal/types.ts
@@ -18,10 +18,10 @@ export type DroppedUrl = {
   errors: Array<Error>;
 };
 
-export type FileUploadStatus = "pending" | "uploaded" | "error";
+export type UploadStatus = "loading" | "uploaded" | "error";
 
-export type FileUploadInfo = {
-  status: FileUploadStatus;
+export type UploadInfo = {
+  status: UploadStatus;
   error?: string;
   warnings?: string[];
 };
@@ -30,9 +30,9 @@ export type FileUploadInfo = {
  * A lookup table containing only the status of
  * the file being uploaded
  */
-export type FileUploadInfoRecord = Record<string, FileUploadInfo>;
+export type UploadInfoRecord = Record<string, UploadInfo>;
 
 /**
  * Setter function for the upload statuses
  */
-export type SetUploadInfoRecord = SetState<FileUploadInfoRecord>;
+export type SetUploadInfo = SetState<UploadInfoRecord>;

--- a/typescript/web/src/components/import-button/import-images-modal/types.ts
+++ b/typescript/web/src/components/import-button/import-images-modal/types.ts
@@ -26,7 +26,7 @@ export type UploadStatuses = Record<string, boolean | string>;
 
 export type UploadInfo = {
   status: boolean | string;
-  datasetSkippedCrowdAnnotations?: number;
+  warnings: string[];
 };
 export type UploadInfos = Record<string, UploadInfo>;
 

--- a/typescript/web/src/components/import-button/import-images-modal/types.ts
+++ b/typescript/web/src/components/import-button/import-images-modal/types.ts
@@ -28,10 +28,10 @@ export type UploadInfo = {
   status: boolean | string;
   warnings: string[];
 };
-export type UploadInfos = Record<string, UploadInfo>;
+export type UploadInfoRecord = Record<string, UploadInfo>;
 
 /**
  * Setter function for the upload statuses
  */
 export type SetUploadStatuses = SetState<UploadStatuses>;
-export type SetUploadInfos = SetState<UploadInfos>;
+export type SetUploadInfoRecord = SetState<UploadInfoRecord>;

--- a/typescript/web/src/components/import-button/import-images-modal/types.ts
+++ b/typescript/web/src/components/import-button/import-images-modal/types.ts
@@ -18,20 +18,21 @@ export type DroppedUrl = {
   errors: Array<Error>;
 };
 
+export type FileUploadStatus = "pending" | "uploaded" | "error";
+
+export type FileUploadInfo = {
+  status: FileUploadStatus;
+  error?: string;
+  warnings?: string[];
+};
+
 /**
  * A lookup table containing only the status of
  * the file being uploaded
  */
-export type UploadStatuses = Record<string, boolean | string>;
-
-export type UploadInfo = {
-  status: boolean | string;
-  warnings: string[];
-};
-export type UploadInfoRecord = Record<string, UploadInfo>;
+export type FileUploadInfoRecord = Record<string, FileUploadInfo>;
 
 /**
  * Setter function for the upload statuses
  */
-export type SetUploadStatuses = SetState<UploadStatuses>;
-export type SetUploadInfoRecord = SetState<UploadInfoRecord>;
+export type SetUploadInfoRecord = SetState<FileUploadInfoRecord>;


### PR DESCRIPTION
## Work performed

- Prevented COCO import from trowing an error when encountering crowd/RLE annotations, skipping them instead.
- On import modal:
  - Added a message with the number of ignored crowd/RLE annotations if there are any.
  - Changed the icon for JSON files and ZIP files.

## Resolved issues

#860 
