### PR TITLE
Fix workspace not found error after creation

### DIFF
--- a/typescript/web/src/components/workspace-switcher/create-workspace-modal/create-workspace.mutation.ts
+++ b/typescript/web/src/components/workspace-switcher/create-workspace-modal/create-workspace.mutation.ts
@@ -106,6 +106,7 @@ export function useCreateWorkspaceMutation(
   >(CREATE_WORKSPACE_MUTATION, {
     variables: { name: workspaceName },
     refetchQueries: [USER_WITH_WORKSPACES_QUERY],
+    awaitRefetchQueries: true,
     onCompleted,
     onError,
   });


### PR DESCRIPTION
## Work performed

On workspace creation, make the mutation await the `refetchQueries` before changing its status to be complete.

## Results

No more errors after workspace creation.

## Resolved issues

#877 
