### PR TITLE
Add extra delay in the loading state tests of useImagesNavigation

### DIFF
--- a/typescript/web/src/hooks/use-image-navigation.fixtures.ts
+++ b/typescript/web/src/hooks/use-image-navigation.fixtures.ts
@@ -27,7 +27,7 @@ const CURRENT_IMAGE_NOT_PRESENT = [IMAGE_1_DATA, IMAGE_2_DATA, IMAGE_3_DATA];
 
 const createImagesGenerator = (
   images: GetAllImagesOfADatasetQuery_dataset_images[],
-  delay?: number
+  delay: number = 10
 ): ApolloMockResponse<
   GetAllImagesOfADatasetQuery,
   GetAllImagesOfADatasetQueryVariables

--- a/typescript/web/src/hooks/use-image-navigation.fixtures.ts
+++ b/typescript/web/src/hooks/use-image-navigation.fixtures.ts
@@ -26,7 +26,8 @@ const CURRENT_IMAGE_IS_LAST = [IMAGE_1_DATA, IMAGE_2_DATA, CURRENT_IMAGE_DATA];
 const CURRENT_IMAGE_NOT_PRESENT = [IMAGE_1_DATA, IMAGE_2_DATA, IMAGE_3_DATA];
 
 const createImagesGenerator = (
-  images: GetAllImagesOfADatasetQuery_dataset_images[]
+  images: GetAllImagesOfADatasetQuery_dataset_images[],
+  delay?: number
 ): ApolloMockResponse<
   GetAllImagesOfADatasetQuery,
   GetAllImagesOfADatasetQueryVariables
@@ -46,26 +47,24 @@ const createImagesGenerator = (
       },
     },
   },
-  delay: 10,
+  delay,
 });
 
 const createImagesMocks = (
-  images: GetAllImagesOfADatasetQuery_dataset_images[]
-): ApolloMockResponses => [createImagesGenerator(images)];
+  images: GetAllImagesOfADatasetQuery_dataset_images[],
+  delay?: number
+): ApolloMockResponses => [createImagesGenerator(images, delay)];
 
-export const THREE_IMAGES_MOCKS: ApolloMockResponses = createImagesMocks(
-  CURRENT_IMAGE_IS_SECOND
+export const THREE_IMAGES_MOCKS = createImagesMocks(CURRENT_IMAGE_IS_SECOND);
+
+export const IMAGE_IS_FIRST_MOCKS = createImagesMocks(CURRENT_IMAGE_IS_FIRST);
+
+export const IMAGE_IS_LAST_MOCKS = createImagesMocks(CURRENT_IMAGE_IS_LAST);
+
+export const NO_IMAGES_MOCKS = createImagesMocks([]);
+
+export const NO_IMAGES_MOCKS_WITH_DELAY = createImagesMocks([], 100);
+
+export const CURRENT_NOT_IN_IMAGES_MOCKS = createImagesMocks(
+  CURRENT_IMAGE_NOT_PRESENT
 );
-
-export const IMAGE_IS_FIRST_MOCKS: ApolloMockResponses = createImagesMocks(
-  CURRENT_IMAGE_IS_FIRST
-);
-
-export const IMAGE_IS_LAST_MOCKS: ApolloMockResponses = createImagesMocks(
-  CURRENT_IMAGE_IS_LAST
-);
-
-export const NO_IMAGES_MOCKS: ApolloMockResponses = createImagesMocks([]);
-
-export const CURRENT_NOT_IN_IMAGES_MOCKS: ApolloMockResponses =
-  createImagesMocks(CURRENT_IMAGE_NOT_PRESENT);

--- a/typescript/web/src/hooks/use-images-navigation.test.tsx
+++ b/typescript/web/src/hooks/use-images-navigation.test.tsx
@@ -9,6 +9,7 @@ import {
   IMAGE_IS_FIRST_MOCKS,
   IMAGE_IS_LAST_MOCKS,
   NO_IMAGES_MOCKS,
+  NO_IMAGES_MOCKS_WITH_DELAY,
   THREE_IMAGES_MOCKS,
 } from "./use-image-navigation.fixtures";
 
@@ -39,7 +40,7 @@ const renderTest = async (extraMocks: ApolloMockResponses) => {
 
 describe(useImagesNavigation, () => {
   it("has an undefined currentImageIndex while loading", async () => {
-    const { result } = await renderTest(NO_IMAGES_MOCKS);
+    const { result } = await renderTest(NO_IMAGES_MOCKS_WITH_DELAY);
     expect(result.current.currentImageIndex).toEqual(undefined);
   });
 
@@ -69,7 +70,7 @@ describe(useImagesNavigation, () => {
 
   describe("Previous and Next ids", () => {
     it("has undefined previous and next ids while loading", async () => {
-      const { result } = await renderTest(NO_IMAGES_MOCKS);
+      const { result } = await renderTest(NO_IMAGES_MOCKS_WITH_DELAY);
       expect(result.current.previousImageId).toEqual(undefined);
       expect(result.current.nextImageId).toEqual(undefined);
     });

--- a/typescript/web/src/pages/auth/signin.tsx
+++ b/typescript/web/src/pages/auth/signin.tsx
@@ -11,7 +11,7 @@ const useRedirectIfAuthenticated = (redirectUrl?: string) => {
   const router = useRouter();
   useEffect(() => {
     if (status === "authenticated") {
-      router.replace(redirectUrl || `/`);
+      router.replace(redirectUrl || "/");
     }
   });
 };


### PR DESCRIPTION
## Work performed

<!--- Concisely describe what was done, this will appear in the public changelog -->
CI tests are sometimes failing because of a supposed race-condition in use-images-navigation test for values while loading.
I've increased the query response delay so that we can hope that the expectations will be tested before the query has ended-up being executed.

## Results

<!--- Does this pull-request fully implement the new feature? If not why? Create and link new issues. -->
Test should not be flacky anymore

## Problems encountered

<!--- Explain problems that were encountered when implementing this pull-request -->
I can't reproduce the issue on my machine

## Caveats

<!--- Any particular attention point with what you did? -->
There is a 100ms forced delay in the corresponding tests

## Resolved issues

<!--- List references to issues that this PR resolves -->
No

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
No