### PR TITLE
Make the /local fallback page redirect to /workspaces when appropriate

### DIFF
--- a/typescript/web/src/components/logo/nav-logo.tsx
+++ b/typescript/web/src/components/logo/nav-logo.tsx
@@ -1,22 +1,26 @@
-import { Box, VisuallyHidden, BreadcrumbLink } from "@chakra-ui/react";
-import { isNil } from "lodash/fp";
-
+import { Box, BreadcrumbLink, VisuallyHidden } from "@chakra-ui/react";
+import { isEmpty, isNil } from "lodash/fp";
 import NextLink from "next/link";
 import { useOptionalWorkspace } from "../../hooks";
-
 import { Logo } from "./logo";
 
-export const NavLogo = () => {
-  const workspace = useOptionalWorkspace();
-  const href = isNil(workspace) ? "/" : "/workspaces";
-  return (
-    <NextLink href={href}>
-      <BreadcrumbLink flexShrink={0} flexGrow={0}>
-        <Box rel="home" cursor="pointer" mr="0" overflow="visible">
-          <VisuallyHidden>LabelFlow</VisuallyHidden>
-          <Logo h="8" iconColor="brand.500" logoOnly />
-        </Box>
-      </BreadcrumbLink>
-    </NextLink>
-  );
+export type NavLogoProps = {
+  href?: string;
 };
+
+const useNavLogoHref = (href: string | undefined): string => {
+  const workspace = useOptionalWorkspace();
+  if (!isNil(href) && !isEmpty(href)) return href;
+  return isNil(workspace) ? "/" : "/workspaces";
+};
+
+export const NavLogo = ({ href }: NavLogoProps) => (
+  <NextLink href={useNavLogoHref(href)}>
+    <BreadcrumbLink flexShrink={0} flexGrow={0}>
+      <Box rel="home" cursor="pointer" mr="0" overflow="visible">
+        <VisuallyHidden>LabelFlow</VisuallyHidden>
+        <Logo h="8" iconColor="brand.500" logoOnly />
+      </Box>
+    </BreadcrumbLink>
+  </NextLink>
+);


### PR DESCRIPTION
## Work performed

<!--- Concisely describe what was done, this will appear in the public changelog -->
I've changed the LocalWorkspaceFallback component code so that it redirects to `/workspaces` when a user is authenticated and has at-least 1 workspace.

## Results

<!--- Does this pull-request fully implement the new feature? If not why? Create and link new issues. -->
Users should not be automatically redirected to `lastWorkspaceId`

## Problems encountered

<!--- Explain problems that were encountered when implementing this pull-request -->
Code needed a bit of factorization so I've used a context to ensure a "purely-functional" state.

## Caveats

<!--- Any particular attention point with what you did? -->
Until we have a real homepage, we'll have to use this hacky behavior.

## Resolved issues

<!--- List references to issues that this PR resolves -->
Not created (was mentioned during the DSM)

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
* Change the URLs and simplify the code (remove context) once we have a real homepage (or remove this whole `/local` fallback if month have passed since)