### PR TITLE
Import / Export classes as CSV in a dataset

### DIFF
--- a/cypress/integration/dataset-classes.ts
+++ b/cypress/integration/dataset-classes.ts
@@ -1,0 +1,33 @@
+import { DATASET_SLUG, WORKSPACE_SLUG } from "../fixtures";
+
+const TEST_CLASSES = ["cat", "dog", "hedgehog"];
+
+const getClassTd = (name: string) =>
+  cy.get('[data-testid="reorderable-table-body"]').contains("td", name);
+
+const visibleClasses = (labelClasses: string[]): void =>
+  labelClasses.forEach((labelClass) =>
+    getClassTd(labelClass).should("be.visible")
+  );
+
+describe("Dataset Classes", () => {
+  it("Adds many label-classes at once and searches for one of them", () => {
+    cy.task("performLogin").then((token) => {
+      cy.setCookie("next-auth.session-token", token as string);
+    });
+    cy.task("createWorkspaceAndDatasets");
+    cy.setCookie("consentedCookies", "true");
+    cy.visit(`/${WORKSPACE_SLUG}/datasets/${DATASET_SLUG}/classes`);
+    cy.get('[data-testid="add-button"]').should("be.visible");
+    cy.get('[data-testid="add-button"]').click();
+    cy.get('[data-testid="class-names-input"]').should("be.visible");
+    cy.get('[data-testid="class-names-input"]').type(TEST_CLASSES.join("\n"));
+    cy.get('[data-testid="create-classes-button"]').click();
+    cy.get('[data-testid="add-button"]').should("be.visible");
+    visibleClasses(TEST_CLASSES);
+    cy.get('[data-testid="search-input"]').type("og");
+    const [cat, ...containsOg] = TEST_CLASSES;
+    getClassTd(cat).should("not.exist");
+    visibleClasses(containsOg);
+  });
+});

--- a/data/__generated__/schema.graphql
+++ b/data/__generated__/schema.graphql
@@ -274,6 +274,17 @@ input LabelClassCreateInput {
   datasetId: ID!
 }
 
+input LabelClassCreateManyInput {
+  labelClasses: [LabelClassCreateManySingleInput!]!
+  datasetId: ID!
+}
+
+input LabelClassCreateManySingleInput {
+  id: ID
+  name: String!
+  color: ColorHex
+}
+
 input LabelClassReorderInput {
   index: Int!
 }
@@ -386,6 +397,7 @@ type Mutation {
   updateLabel(where: LabelWhereUniqueInput!, data: LabelUpdateInput!): Label
   deleteLabel(where: LabelWhereUniqueInput!): Label
   createLabelClass(data: LabelClassCreateInput!): LabelClass
+  createManyLabelClasses(data: LabelClassCreateManyInput!): [LabelClass!]!
   updateLabelClass(where: LabelClassWhereUniqueInput!, data: LabelClassUpdateInput!): LabelClass
   reorderLabelClass(where: LabelClassWhereUniqueInput!, data: LabelClassReorderInput!): LabelClass
   deleteLabelClass(where: LabelClassWhereUniqueInput!): LabelClass

--- a/data/label-class.graphql
+++ b/data/label-class.graphql
@@ -5,6 +5,17 @@ input LabelClassCreateInput {
   datasetId: ID!
 }
 
+input LabelClassCreateManySingleInput {
+  id: ID
+  name: String!
+  color: ColorHex
+}
+
+input LabelClassCreateManyInput {
+  labelClasses: [LabelClassCreateManySingleInput!]!
+  datasetId: ID!
+}
+
 input LabelClassUpdateInput {
   name: String
   color: ColorHex

--- a/data/mutations.graphql
+++ b/data/mutations.graphql
@@ -12,6 +12,7 @@ type Mutation {
   deleteLabel(where: LabelWhereUniqueInput!): Label
 
   createLabelClass(data: LabelClassCreateInput!): LabelClass
+  createManyLabelClasses(data: LabelClassCreateManyInput!): [LabelClass!]!
   updateLabelClass(
     where: LabelClassWhereUniqueInput!
     data: LabelClassUpdateInput!

--- a/typescript/common-resolvers/src/export/export-to-csv.ts
+++ b/typescript/common-resolvers/src/export/export-to-csv.ts
@@ -1,26 +1,9 @@
 import { ExportOptionsCsv } from "@labelflow/graphql-types";
-import {
-  Options as StringifyCsvOptions,
-  stringify as stringifyCsv,
-} from "csv-stringify";
 import { isNil } from "lodash";
 import { Context, DbDataset, DbImage, DbLabel, DbLabelClass } from "../types";
+import { stringifyCsv } from "../utils";
 import { getOrigin } from "../utils/get-origin";
 import { ExportFunction } from "./types";
-
-const stringifyCsvAsync = (
-  rows: unknown[][],
-  options?: StringifyCsvOptions
-): Promise<string> =>
-  new Promise((resolve, reject) => {
-    stringifyCsv(rows, options, (error, output) => {
-      if (error) {
-        reject(error);
-      } else {
-        resolve(output);
-      }
-    });
-  });
 
 // https://github.com/labelflow/labelflow/issues/879
 const CSV_HEADER = [
@@ -132,7 +115,7 @@ export const createCsv = async (
   ctx: Context
 ): Promise<string> => {
   const rows = await createRowsFromDb(datasetId, ctx);
-  const csv = await stringifyCsvAsync(rows, {
+  const csv = await stringifyCsv(rows, {
     header: true,
     columns: CSV_HEADER,
   });

--- a/typescript/common-resolvers/src/types.ts
+++ b/typescript/common-resolvers/src/types.ts
@@ -180,10 +180,19 @@ export type Repository = {
   };
   labelClass: {
     add: Add<DbLabelClassCreateInput>;
+    addMany: (
+      args: { labelClasses: DbLabelClassCreateInput[] },
+      user?: { id: string }
+    ) => Promise<ID[]>;
     count: Count<LabelClassWhereInput & { user?: { id: string } }>;
     delete: Delete<LabelClassWhereUniqueInput>;
     get: Get<DbLabelClass, LabelClassWhereUniqueInput>;
-    list: List<DbLabelClass, LabelClassWhereInput & { user?: { id: string } }>;
+    list: List<
+      DbLabelClass,
+      LabelClassWhereInput & { user?: { id: string } } & {
+        id?: string | { in: string[] };
+      }
+    >;
     update: Update<DbLabelClass, LabelClassWhereUniqueInput>;
   };
   dataset: {

--- a/typescript/common-resolvers/src/utils/index.ts
+++ b/typescript/common-resolvers/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./get-slug";
 export * from "./validate-workspace-name";
 export * from "./add-typename";
+export * from "./stringify-csv";

--- a/typescript/common-resolvers/src/utils/stringify-csv.ts
+++ b/typescript/common-resolvers/src/utils/stringify-csv.ts
@@ -1,0 +1,15 @@
+import { Options as StringifyCsvOptions, stringify } from "csv-stringify";
+
+export const stringifyCsv = (
+  rows: unknown[][],
+  options?: StringifyCsvOptions
+): Promise<string> =>
+  new Promise((resolve, reject) => {
+    stringify(rows, options, (error, output) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(output);
+      }
+    });
+  });

--- a/typescript/db/src/__generated__/schema.ts
+++ b/typescript/db/src/__generated__/schema.ts
@@ -276,6 +276,17 @@ export const typeDefs = [
     datasetId: ID!
   }
 
+  input LabelClassCreateManyInput {
+    labelClasses: [LabelClassCreateManySingleInput!]!
+    datasetId: ID!
+  }
+
+  input LabelClassCreateManySingleInput {
+    id: ID
+    name: String!
+    color: ColorHex
+  }
+
   input LabelClassReorderInput {
     index: Int!
   }
@@ -388,6 +399,7 @@ export const typeDefs = [
     updateLabel(where: LabelWhereUniqueInput!, data: LabelUpdateInput!): Label
     deleteLabel(where: LabelWhereUniqueInput!): Label
     createLabelClass(data: LabelClassCreateInput!): LabelClass
+    createManyLabelClasses(data: LabelClassCreateManyInput!): [LabelClass!]!
     updateLabelClass(where: LabelClassWhereUniqueInput!, data: LabelClassUpdateInput!): LabelClass
     reorderLabelClass(where: LabelClassWhereUniqueInput!, data: LabelClassReorderInput!): LabelClass
     deleteLabelClass(where: LabelClassWhereUniqueInput!): LabelClass

--- a/typescript/db/src/resolvers/__tests__/label-class.test.ts
+++ b/typescript/db/src/resolvers/__tests__/label-class.test.ts
@@ -112,8 +112,16 @@ describe("Access control for label-class", () => {
 
   it("gives the amount of label classes the user has access to", async () => {
     await createLabelClass(labelClassData);
-    await createLabelClass({ ...labelClassData, id: undefined });
-    await createLabelClass({ ...labelClassData, id: undefined });
+    await createLabelClass({
+      ...labelClassData,
+      id: undefined,
+      name: `${labelClassData.name} 2`,
+    });
+    await createLabelClass({
+      ...labelClassData,
+      id: undefined,
+      name: `${labelClassData.name} 3`,
+    });
     const { data } = await client.query({
       query: gql`
         query labelClasses {
@@ -133,8 +141,16 @@ describe("Access control for label-class", () => {
 
   it("returns zero elements if user does not have access to any label class", async () => {
     await createLabelClass(labelClassData);
-    await createLabelClass({ ...labelClassData, id: undefined });
-    await createLabelClass({ ...labelClassData, id: undefined });
+    await createLabelClass({
+      ...labelClassData,
+      id: undefined,
+      name: `${labelClassData.name} 2`,
+    });
+    await createLabelClass({
+      ...labelClassData,
+      id: undefined,
+      name: `${labelClassData.name} 3`,
+    });
     user.id = testUser2Id;
     const { data } = await client.query({
       query: gql`

--- a/typescript/graphql-types/src/graphql-types.generated.ts
+++ b/typescript/graphql-types/src/graphql-types.generated.ts
@@ -304,6 +304,17 @@ export type LabelClassCreateInput = {
   datasetId: Scalars['ID'];
 };
 
+export type LabelClassCreateManyInput = {
+  labelClasses: Array<LabelClassCreateManySingleInput>;
+  datasetId: Scalars['ID'];
+};
+
+export type LabelClassCreateManySingleInput = {
+  id?: Maybe<Scalars['ID']>;
+  name: Scalars['String'];
+  color?: Maybe<Scalars['ColorHex']>;
+};
+
 export type LabelClassReorderInput = {
   index: Scalars['Int'];
 };
@@ -420,6 +431,7 @@ export type Mutation = {
   updateLabel?: Maybe<Label>;
   deleteLabel?: Maybe<Label>;
   createLabelClass?: Maybe<LabelClass>;
+  createManyLabelClasses: Array<LabelClass>;
   updateLabelClass?: Maybe<LabelClass>;
   reorderLabelClass?: Maybe<LabelClass>;
   deleteLabelClass?: Maybe<LabelClass>;
@@ -491,6 +503,11 @@ export type MutationDeleteLabelArgs = {
 
 export type MutationCreateLabelClassArgs = {
   data: LabelClassCreateInput;
+};
+
+
+export type MutationCreateManyLabelClassesArgs = {
+  data: LabelClassCreateManyInput;
 };
 
 
@@ -983,6 +1000,8 @@ export type ResolversTypes = {
   Label: ResolverTypeWrapper<Label>;
   LabelClass: ResolverTypeWrapper<LabelClass>;
   LabelClassCreateInput: LabelClassCreateInput;
+  LabelClassCreateManyInput: LabelClassCreateManyInput;
+  LabelClassCreateManySingleInput: LabelClassCreateManySingleInput;
   LabelClassReorderInput: LabelClassReorderInput;
   LabelClassUpdateInput: LabelClassUpdateInput;
   LabelClassWhereInput: LabelClassWhereInput;
@@ -1067,6 +1086,8 @@ export type ResolversParentTypes = {
   Label: Label;
   LabelClass: LabelClass;
   LabelClassCreateInput: LabelClassCreateInput;
+  LabelClassCreateManyInput: LabelClassCreateManyInput;
+  LabelClassCreateManySingleInput: LabelClassCreateManySingleInput;
   LabelClassReorderInput: LabelClassReorderInput;
   LabelClassUpdateInput: LabelClassUpdateInput;
   LabelClassWhereInput: LabelClassWhereInput;
@@ -1241,6 +1262,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   updateLabel?: Resolver<Maybe<ResolversTypes['Label']>, ParentType, ContextType, RequireFields<MutationUpdateLabelArgs, 'where' | 'data'>>;
   deleteLabel?: Resolver<Maybe<ResolversTypes['Label']>, ParentType, ContextType, RequireFields<MutationDeleteLabelArgs, 'where'>>;
   createLabelClass?: Resolver<Maybe<ResolversTypes['LabelClass']>, ParentType, ContextType, RequireFields<MutationCreateLabelClassArgs, 'data'>>;
+  createManyLabelClasses?: Resolver<Array<ResolversTypes['LabelClass']>, ParentType, ContextType, RequireFields<MutationCreateManyLabelClassesArgs, 'data'>>;
   updateLabelClass?: Resolver<Maybe<ResolversTypes['LabelClass']>, ParentType, ContextType, RequireFields<MutationUpdateLabelClassArgs, 'where' | 'data'>>;
   reorderLabelClass?: Resolver<Maybe<ResolversTypes['LabelClass']>, ParentType, ContextType, RequireFields<MutationReorderLabelClassArgs, 'where' | 'data'>>;
   deleteLabelClass?: Resolver<Maybe<ResolversTypes['LabelClass']>, ParentType, ContextType, RequireFields<MutationDeleteLabelClassArgs, 'where'>>;

--- a/typescript/web/package.json
+++ b/typescript/web/package.json
@@ -52,6 +52,7 @@
     "autoprefixer": "10.2.6",
     "bluebird": "3.7.2",
     "browser-builtins": "3.3.1",
+    "csv-stringify": "6.0.5",
     "date-fns": "2.23.0",
     "detect-browser": "5.2.0",
     "downshift": "6.1.3",

--- a/typescript/web/src/components/dataset-classes/__snapshots__/dataset-classes-export.test.ts.snap
+++ b/typescript/web/src/components/dataset-classes/__snapshots__/dataset-classes-export.test.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LabelClasses CSV export Generates proper CSV 1`] = `
+"Test Class With Labels 1
+\\"Test Class With Labels, 2\\"
+"
+`;

--- a/typescript/web/src/components/dataset-classes/add-classes-modal/add-classes-modal-context.tsx
+++ b/typescript/web/src/components/dataset-classes/add-classes-modal/add-classes-modal-context.tsx
@@ -1,0 +1,185 @@
+import { ApolloError } from "@apollo/client";
+import { isEmpty } from "lodash/fp";
+import {
+  createContext,
+  Dispatch,
+  PropsWithChildren,
+  SetStateAction,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { useDebounce } from "use-debounce";
+import { useDatasetClasses } from "../dataset-classes.context";
+import { useCreateManyLabelClassesMutation } from "./create-many-label-classes.mutation";
+
+export type AddClassesModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export type ValueState = { value: string; error: string };
+
+export type AddClassesModalState = ValueState & {
+  setValue: (value: string) => void;
+  submit: () => Promise<void>;
+  count: number;
+  duplicates: number;
+  loading: boolean;
+  canSubmit: boolean;
+};
+
+const AddClassesModalContext = createContext({} as AddClassesModalState);
+
+export const useAddClassesModal = () => useContext(AddClassesModalContext);
+
+type UseValueResult = {
+  state: ValueState;
+  setState: Dispatch<SetStateAction<ValueState>>;
+  setValue: Dispatch<ValueState["value"]>;
+  setError: Dispatch<ValueState["error"]>;
+};
+
+const useValue = (): UseValueResult => {
+  const [state, setState] = useState<ValueState>({ value: "", error: "" });
+  const setValue = (value: string) => setState({ value, error: "" });
+  const setError = (error: string) =>
+    setState((oldState) => ({ ...oldState, error }));
+  return { state, setState, setValue, setError };
+};
+
+const useModalObserver = (
+  isOpen: boolean,
+  setValueState: Dispatch<SetStateAction<ValueState>>
+) => {
+  useEffect(() => {
+    if (isOpen) return;
+    setValueState({ value: "", error: "" });
+  }, [isOpen, setValueState]);
+};
+
+const parseClassNames = (text: string): string[] =>
+  text
+    .split("\n")
+    .map((className) => className.trim())
+    .filter((name) => !isEmpty(name));
+
+type FindDuplicatesOptions = {
+  classNames: string[];
+  existing: ReturnType<typeof useDatasetClasses>["labelClasses"];
+};
+
+type FindDuplicatesResult = { classNames: string[]; duplicates: number };
+
+const findDuplicates = ({
+  classNames,
+  existing,
+}: FindDuplicatesOptions): FindDuplicatesResult =>
+  classNames.reduce<FindDuplicatesResult>(
+    (prev, className) => {
+      const { classNames: prevUnique, duplicates: prevDuplicates } = prev;
+      const isDuplicate =
+        existing?.some(({ name }) => className === name) ||
+        prevUnique.includes(className);
+      return isDuplicate
+        ? { ...prev, duplicates: prevDuplicates + 1 }
+        : { ...prev, classNames: [...prevUnique, className] };
+    },
+    { classNames: [], duplicates: 0 }
+  );
+
+type UseParseClassNamesOptions = Pick<AddClassesModalState, "value">;
+
+type UseParseClassNamesResult = FindDuplicatesResult & { debouncing: boolean };
+
+const useParseClassNames = ({
+  value,
+}: UseParseClassNamesOptions): UseParseClassNamesResult => {
+  const [debounced] = useDebounce(value, 250, {
+    leading: true,
+    trailing: true,
+  });
+  const { labelClasses: existing } = useDatasetClasses();
+  const result = useMemo(() => {
+    const classNames = parseClassNames(debounced);
+    return findDuplicates({ classNames, existing });
+  }, [existing, debounced]);
+  return { ...result, debouncing: value !== debounced };
+};
+
+type UseSubmitOptions = Pick<FindDuplicatesResult, "classNames"> &
+  Pick<AddClassesModalState, "canSubmit"> &
+  Pick<AddClassesModalProps, "onClose"> &
+  Pick<UseValueResult, "setError">;
+
+type UseSubmitResult = { submit: () => Promise<void>; loading: boolean };
+
+const useSubmit = ({
+  classNames,
+  canSubmit,
+  onClose,
+  setError,
+}: UseSubmitOptions): UseSubmitResult => {
+  const { datasetId = "" } = useDatasetClasses();
+  const [createLabelClasses, { loading }] = useCreateManyLabelClassesMutation(
+    classNames,
+    datasetId
+  );
+  const submit = useCallback(async () => {
+    if (!canSubmit) return;
+    try {
+      await createLabelClasses();
+      onClose();
+    } catch (error) {
+      if (error instanceof ApolloError) {
+        setError(error.message);
+      } else {
+        throw error;
+      }
+    }
+  }, [canSubmit, createLabelClasses, onClose, setError]);
+  return { submit, loading };
+};
+
+const useProvider = ({
+  isOpen,
+  onClose,
+}: AddClassesModalProps): AddClassesModalState => {
+  const { loading: datasetLoading } = useDatasetClasses();
+  const {
+    state: { value, error },
+    setState: setValueState,
+    setValue,
+    setError,
+  } = useValue();
+  const { classNames, duplicates, debouncing } = useParseClassNames({ value });
+  const canSubmit = !debouncing && !datasetLoading && classNames.length > 0;
+  const submitOpts = { classNames, canSubmit, onClose, setError };
+  const { submit, loading: submitting } = useSubmit(submitOpts);
+  const loading = submitting || datasetLoading;
+  useModalObserver(isOpen, setValueState);
+  return {
+    value,
+    error,
+    submit,
+    count: classNames.length,
+    setValue,
+    duplicates,
+    loading,
+    canSubmit: canSubmit && !submitting,
+  };
+};
+
+export type AddClassesModalProviderProps =
+  PropsWithChildren<AddClassesModalProps>;
+
+export const AddClassesModalProvider = ({
+  children,
+  ...props
+}: AddClassesModalProviderProps) => (
+  <AddClassesModalContext.Provider value={useProvider(props)}>
+    {children}
+  </AddClassesModalContext.Provider>
+);

--- a/typescript/web/src/components/dataset-classes/add-classes-modal/add-classes-modal.fixtures.ts
+++ b/typescript/web/src/components/dataset-classes/add-classes-modal/add-classes-modal.fixtures.ts
@@ -1,0 +1,36 @@
+import { v4 as uuid } from "uuid";
+import { MATCH_ANY_PARAMETERS } from "wildcard-mock-link";
+import {
+  CreateManyLabelClassesMutation,
+  CreateManyLabelClassesMutationVariables,
+} from "../../../graphql-types";
+import { DEEP_DATASET_WITH_CLASSES_DATA } from "../../../utils/fixtures";
+import { ApolloMockResponse, ApolloMockResponses } from "../../../utils/tests";
+import { LabelClassWithShortcut } from "../types";
+import { CREATE_MANY_LABEL_CLASSES_MUTATION } from "./create-many-label-classes.mutation";
+
+export const UPDATED_LABEL_CLASS_MOCK_NAME = "My New Class Name";
+
+export const LABEL_CLASSES_DATA: LabelClassWithShortcut[] =
+  DEEP_DATASET_WITH_CLASSES_DATA.labelClasses;
+
+export const CREATE_MANY_LABEL_CLASSES_MOCK: ApolloMockResponse<
+  CreateManyLabelClassesMutation,
+  CreateManyLabelClassesMutationVariables
+> = {
+  request: {
+    query: CREATE_MANY_LABEL_CLASSES_MUTATION,
+    variables: MATCH_ANY_PARAMETERS,
+  },
+  result: jest.fn((variables) => ({
+    data: {
+      createManyLabelClasses: variables.labelClasses.map(() => ({
+        id: uuid(),
+      })),
+    },
+  })),
+};
+
+export const APOLLO_MOCKS: ApolloMockResponses = [
+  CREATE_MANY_LABEL_CLASSES_MOCK,
+];

--- a/typescript/web/src/components/dataset-classes/add-classes-modal/add-classes-modal.stories.tsx
+++ b/typescript/web/src/components/dataset-classes/add-classes-modal/add-classes-modal.stories.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { AddClassesModal as AddClassesModalComponent } from ".";
+import { storybookTitle } from "../../../utils/stories";
+import { getApolloMockDecorator } from "../../../utils/stories/apollo-mock-decorator";
+import { chakraDecorator } from "../../../utils/stories/chakra-decorator";
+
+export default {
+  title: storybookTitle(AddClassesModalComponent),
+  decorators: [chakraDecorator, getApolloMockDecorator()],
+};
+
+export const AddClassesModal = () => (
+  <AddClassesModalComponent isOpen onClose={() => {}} />
+);

--- a/typescript/web/src/components/dataset-classes/add-classes-modal/add-classes-modal.test.tsx
+++ b/typescript/web/src/components/dataset-classes/add-classes-modal/add-classes-modal.test.tsx
@@ -1,0 +1,139 @@
+import "@testing-library/jest-dom/extend-expect";
+import { fireEvent, waitFor } from "@testing-library/react";
+import {
+  BASIC_LABEL_CLASS_DATA,
+  DEEP_DATASET_WITH_CLASSES_DATA,
+} from "../../../utils/fixtures";
+import { mockWorkspace } from "../../../utils/tests/mock-workspace";
+
+mockWorkspace({
+  queryParams: { datasetSlug: BASIC_LABEL_CLASS_DATA.dataset.slug },
+});
+
+import {
+  renderWithTestWrapper,
+  RenderWithWrapperResult,
+} from "../../../utils/tests";
+import {
+  DatasetClassesContext,
+  DatasetClassesState,
+} from "../dataset-classes.context";
+import {
+  APOLLO_MOCKS,
+  CREATE_MANY_LABEL_CLASSES_MOCK,
+} from "./add-classes-modal.fixtures";
+
+jest.mock(
+  "use-debounce",
+  jest.fn(() => ({ useDebounce: (value: unknown) => [value] }))
+);
+
+import { AddClassesModal } from ".";
+
+const onClose = jest.fn();
+
+type TestComponentProps = Pick<
+  DatasetClassesState,
+  "editClass" | "datasetId" | "datasetSlug" | "labelClasses"
+>;
+
+const renderTest = async (
+  props: Omit<TestComponentProps, "datasetSlug">
+): Promise<RenderWithWrapperResult> => {
+  const result = await renderWithTestWrapper(
+    <DatasetClassesContext.Provider
+      value={{
+        ...({} as DatasetClassesState),
+        datasetSlug: DEEP_DATASET_WITH_CLASSES_DATA.slug,
+        labelClasses: DEEP_DATASET_WITH_CLASSES_DATA.labelClasses,
+        ...props,
+      }}
+    >
+      <AddClassesModal isOpen onClose={onClose} />
+    </DatasetClassesContext.Provider>,
+    { auth: { withWorkspaces: true }, apollo: { extraMocks: APOLLO_MOCKS } }
+  );
+  const { getByText } = result;
+  await waitFor(() => expect(getByText("Add New Classes")).toBeDefined());
+  return result;
+};
+
+describe(AddClassesModal, () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders create modal with disabled create button by default", async () => {
+    const { getByTestId, getByText } = await renderTest({});
+    const button = getByTestId("create-classes-button");
+    await waitFor(() => {
+      expect(button).toHaveAttribute("disabled");
+      expect(getByText(/0 classes/i)).toBeDefined();
+    });
+  });
+
+  it("enables create button when class names list is not empty", async () => {
+    const { getByTestId, getByText } = await renderTest({});
+    const input = getByTestId("class-names-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "My new class" } });
+    expect(input.value).toBe("My new class");
+    const button = getByTestId("create-classes-button");
+    await waitFor(() => {
+      expect(button).not.toHaveAttribute("disabled");
+      expect(getByText(/1 class/i)).toBeDefined();
+    });
+  });
+
+  it("displays the amount of classes to be creatd", async () => {
+    const { getByTestId, getByText } = await renderTest({});
+    const input = getByTestId("class-names-input") as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { value: "My new class\nMy other new class" },
+    });
+    const button = getByTestId("create-classes-button");
+    await waitFor(() => {
+      expect(button).not.toHaveAttribute("disabled");
+      expect(getByText(/2 classes/i)).toBeDefined();
+    });
+  });
+
+  it("displays a warning message if two of the input names are identical", async () => {
+    const { getByTestId, getByText } = await renderTest({});
+    const input = getByTestId("class-names-input") as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { value: "ClassA\nClassB\nClassA" },
+    });
+    const button = getByTestId("create-classes-button");
+    await waitFor(() => {
+      expect(button).not.toHaveAttribute("disabled");
+      expect(
+        getByText(
+          /2 classes will be created. Duplicate class names are ignored/i
+        )
+      ).toBeDefined();
+    });
+  });
+
+  it("creates label classes when the form is submitted", async () => {
+    const { getByTestId, getByText } = await renderTest({
+      datasetId: BASIC_LABEL_CLASS_DATA.dataset.id,
+      labelClasses: [],
+    });
+    const input = getByTestId("class-names-input") as HTMLInputElement;
+    const button = getByTestId("create-classes-button");
+    fireEvent.change(input, {
+      target: {
+        value: DEEP_DATASET_WITH_CLASSES_DATA.labelClasses
+          .map((labelClass) => labelClass.name)
+          .join("\n"),
+      },
+    });
+    await waitFor(() => {
+      expect(button).not.toHaveAttribute("disabled");
+      expect(getByText(/3 classes/i)).toBeDefined();
+    });
+    fireEvent.click(button);
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(CREATE_MANY_LABEL_CLASSES_MOCK.result).toHaveBeenCalled();
+  });
+});

--- a/typescript/web/src/components/dataset-classes/add-classes-modal/add-classes-modal.tsx
+++ b/typescript/web/src/components/dataset-classes/add-classes-modal/add-classes-modal.tsx
@@ -1,0 +1,149 @@
+import {
+  Button,
+  FormControl,
+  FormErrorMessage,
+  FormHelperText,
+  FormLabel,
+  Heading,
+  Modal,
+  ModalBody as ChakraModalBody,
+  ModalCloseButton,
+  ModalContent as ChakraModalContent,
+  ModalFooter as ChakraModalFooter,
+  ModalHeader as ChakraModalHeader,
+  ModalOverlay,
+  Textarea,
+} from "@chakra-ui/react";
+import { isEmpty } from "lodash/fp";
+import { FormEvent, KeyboardEvent, useCallback } from "react";
+import {
+  AddClassesModalProps,
+  AddClassesModalProvider,
+  useAddClassesModal,
+} from "./add-classes-modal-context";
+
+const Header = () => (
+  <ChakraModalHeader textAlign="center" padding="6">
+    <Heading as="h2" size="lg">
+      Add New Classes
+    </Heading>
+  </ChakraModalHeader>
+);
+
+const NamesLabel = () => <FormLabel>Names</FormLabel>;
+
+const useSubmitOnEnter = () => {
+  const { submit } = useAddClassesModal();
+  return useCallback(
+    async (event: KeyboardEvent) => {
+      if (event.key !== "Enter" || !event.ctrlKey) return;
+      event.preventDefault();
+      await submit();
+    },
+    [submit]
+  );
+};
+
+const NamesInput = () => {
+  const { value, setValue, loading } = useAddClassesModal();
+  return (
+    <Textarea
+      data-testid="class-names-input"
+      value={value}
+      onChange={(event) => setValue(event.target.value)}
+      onKeyDown={useSubmitOnEnter()}
+      disabled={loading}
+      size="md"
+      minH="180"
+      placeholder={"Dog\nCat\n..."}
+      autoFocus
+    />
+  );
+};
+
+const HelperText = () => {
+  const { count, duplicates } = useAddClassesModal();
+  return (
+    <FormHelperText color={duplicates > 0 ? "#EFAB22" : undefined}>
+      {count} class{count !== 1 && "es"}{" "}
+      {duplicates > 0 && "will be created. Duplicate class names are ignored."}
+    </FormHelperText>
+  );
+};
+
+const ErrorMessage = () => {
+  const { error } = useAddClassesModal();
+  return <FormErrorMessage>{error}</FormErrorMessage>;
+};
+
+const NamesFormControl = () => {
+  const { error } = useAddClassesModal();
+  return (
+    <FormControl isInvalid={!isEmpty(error)} isRequired>
+      <NamesLabel />
+      <NamesInput />
+      <HelperText />
+      <ErrorMessage />
+    </FormControl>
+  );
+};
+
+const Body = () => (
+  <ChakraModalBody pt="0">
+    <NamesFormControl />
+  </ChakraModalBody>
+);
+
+const Footer = () => {
+  const { canSubmit } = useAddClassesModal();
+  return (
+    <ChakraModalFooter>
+      <Button
+        type="submit"
+        colorScheme="brand"
+        disabled={!canSubmit}
+        aria-label="Create"
+        data-testid="create-classes-button"
+      >
+        Create
+      </Button>
+    </ChakraModalFooter>
+  );
+};
+
+const Content = () => {
+  const { submit } = useAddClassesModal();
+  const handleSubmit = useCallback(
+    async (event: FormEvent) => {
+      event.preventDefault();
+      await submit();
+    },
+    [submit]
+  );
+  return (
+    <ChakraModalContent as="form" onSubmit={handleSubmit}>
+      <ModalCloseButton />
+      <Header />
+      <Body />
+      <Footer />
+    </ChakraModalContent>
+  );
+};
+
+export const AddClassesModal = (props: AddClassesModalProps) => {
+  const { isOpen, onClose } = props;
+  return (
+    <Modal
+      scrollBehavior="inside"
+      isOpen={isOpen}
+      size="xl"
+      onClose={onClose}
+      isCentered
+    >
+      <ModalOverlay />
+      <AddClassesModalProvider {...props}>
+        <Content />
+      </AddClassesModalProvider>
+    </Modal>
+  );
+};

--- a/typescript/web/src/components/dataset-classes/add-classes-modal/create-many-label-classes.mutation.ts
+++ b/typescript/web/src/components/dataset-classes/add-classes-modal/create-many-label-classes.mutation.ts
@@ -1,0 +1,38 @@
+import { gql, MutationResult, useMutation } from "@apollo/client";
+import { useCallback } from "react";
+import {
+  CreateManyLabelClassesMutation,
+  CreateManyLabelClassesMutationVariables,
+} from "../../../graphql-types/CreateManyLabelClassesMutation";
+
+export const CREATE_MANY_LABEL_CLASSES_MUTATION = gql`
+  mutation CreateManyLabelClassesMutation(
+    $labelClasses: [LabelClassCreateManySingleInput!]!
+    $datasetId: ID!
+  ) {
+    createManyLabelClasses(
+      data: { labelClasses: $labelClasses, datasetId: $datasetId }
+    ) {
+      id
+    }
+  }
+`;
+
+export const useCreateManyLabelClassesMutation = (
+  classNames: string[],
+  datasetId: string
+): [() => Promise<void>, MutationResult<{}>] => {
+  const [createLabelClasses, result] = useMutation<
+    CreateManyLabelClassesMutation,
+    CreateManyLabelClassesMutationVariables
+  >(CREATE_MANY_LABEL_CLASSES_MUTATION, {
+    update: (cache) => cache.evict({ id: `Dataset:${datasetId}` }),
+  });
+  const onCreateLabelClasses = useCallback(async () => {
+    const newClassesData = classNames.map((name) => ({ name }));
+    await createLabelClasses({
+      variables: { labelClasses: newClassesData, datasetId },
+    });
+  }, [classNames, createLabelClasses, datasetId]);
+  return [onCreateLabelClasses, result];
+};

--- a/typescript/web/src/components/dataset-classes/add-classes-modal/index.ts
+++ b/typescript/web/src/components/dataset-classes/add-classes-modal/index.ts
@@ -1,0 +1,1 @@
+export * from "./add-classes-modal";

--- a/typescript/web/src/components/dataset-classes/dataset-classes-export.fixtures.ts
+++ b/typescript/web/src/components/dataset-classes/dataset-classes-export.fixtures.ts
@@ -1,0 +1,22 @@
+import { LabelClassWithShortcut } from "./types";
+
+export const DATASET_SLUG = "test-dataset";
+
+export const LABEL_CLASSES_DATA: LabelClassWithShortcut[] = [
+  {
+    id: "05772060-8431-11ec-947b-dbafef54537e",
+    index: 0,
+    name: "Test Class With Labels 1",
+    color: "#F87171",
+    shortcut: "0",
+    labelsAggregates: { totalCount: 4 },
+  },
+  {
+    id: "f4d74c6a-93eb-11ec-a379-d798908ff78b",
+    index: 1,
+    name: "Test Class With Labels, 2",
+    color: "#123456",
+    shortcut: "1",
+    labelsAggregates: { totalCount: 2 },
+  },
+];

--- a/typescript/web/src/components/dataset-classes/dataset-classes-export.test.ts
+++ b/typescript/web/src/components/dataset-classes/dataset-classes-export.test.ts
@@ -1,0 +1,32 @@
+import { waitFor } from "@testing-library/react";
+import { exportDatasetClasses, generateCsv } from "./dataset-classes-export";
+import {
+  DATASET_SLUG,
+  LABEL_CLASSES_DATA,
+} from "./dataset-classes-export.fixtures";
+
+describe("LabelClasses CSV export", () => {
+  it("Generates proper CSV", async () => {
+    expect(await generateCsv(LABEL_CLASSES_DATA)).toMatchSnapshot();
+  });
+
+  it("Triggers download of the CSV file", async () => {
+    window.URL.createObjectURL = jest.fn();
+    const createElementOriginal = document.createElement.bind(document);
+    const onDownload = jest.fn();
+    jest
+      .spyOn(document, "createElement")
+      .mockImplementation((name, options) => {
+        const element = createElementOriginal(name, options);
+        if (name === "a") {
+          element.click = onDownload;
+        }
+        return element;
+      });
+    await exportDatasetClasses(DATASET_SLUG, LABEL_CLASSES_DATA);
+    await waitFor(() => {
+      expect(window.URL.createObjectURL).toHaveBeenCalledTimes(1);
+      expect(onDownload).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/typescript/web/src/components/dataset-classes/dataset-classes-export.ts
+++ b/typescript/web/src/components/dataset-classes/dataset-classes-export.ts
@@ -1,0 +1,22 @@
+import { stringifyCsv } from "@labelflow/common-resolvers";
+import {
+  getDatasetClassesExportName,
+  triggerClientDownload,
+} from "../../utils";
+import { LabelClassWithShortcut } from "./types";
+
+export const generateCsv = (classes: LabelClassWithShortcut[]) => {
+  const rows = classes.map((labelClass) => [labelClass.name]);
+  return stringifyCsv(rows, { header: false });
+};
+
+export const exportDatasetClasses = async (
+  datasetSlug: string,
+  classes: LabelClassWithShortcut[]
+) => {
+  const csv = await generateCsv(classes);
+  const csvFile = new Blob([csv], { type: "application/csv" });
+  const exportName = getDatasetClassesExportName(datasetSlug);
+  const fileName = `${exportName}.csv`;
+  triggerClientDownload(csvFile, fileName);
+};

--- a/typescript/web/src/components/dataset-classes/dataset-classes.context.tsx
+++ b/typescript/web/src/components/dataset-classes/dataset-classes.context.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from "react";
 import { OnReorderCallback } from "../reorderable-table";
+import { exportDatasetClasses } from "./dataset-classes-export";
 import { useDatasetLabelClassesQuery } from "./dataset-classes.query";
 import { useReorderLabelClassMutation } from "./reorder-label-class.mutation";
 import { LabelClassWithShortcut } from "./types";
@@ -26,6 +27,7 @@ export interface DatasetClassesState {
   labelClasses?: LabelClassWithShortcut[];
   loading: boolean;
   onReorder: OnReorderCallback;
+  onExportClasses(): void;
 }
 
 export const DatasetClassesContext = createContext({} as DatasetClassesState);
@@ -84,6 +86,11 @@ export const DatasetClassesProvider = ({
     [refetch, reorderLabelClass, updateQuery]
   );
 
+  const onExportClasses = useCallback(
+    async () => await exportDatasetClasses(datasetSlug, labelClasses),
+    [datasetSlug, labelClasses]
+  );
+
   const value: DatasetClassesState = {
     datasetSlug,
     datasetId: data?.dataset.id,
@@ -98,6 +105,7 @@ export const DatasetClassesProvider = ({
     labelClasses,
     loading,
     onReorder,
+    onExportClasses,
   };
 
   return (

--- a/typescript/web/src/components/dataset-classes/label-classes-actions.tsx
+++ b/typescript/web/src/components/dataset-classes/label-classes-actions.tsx
@@ -1,23 +1,42 @@
-import { TableActions } from "../table-actions";
+import { BiImport } from "react-icons/bi";
+import { useCallback } from "react";
+import { TableActions, TableActionButton } from "../table-actions";
 import { useDatasetClasses } from "./dataset-classes.context";
-import { UpsertClassModal } from "./upsert-class-modal";
+import { AddClassesModal as AddClassesModalComponent } from "./add-classes-modal";
+
+const DownloadAction = () => {
+  const { onExportClasses } = useDatasetClasses();
+  return (
+    <TableActionButton
+      variant="outline"
+      icon={BiImport}
+      onClick={onExportClasses}
+      label="Download"
+    />
+  );
+};
+
+const AddClassesModal = () => {
+  const { isCreating, setIsCreating } = useDatasetClasses();
+  const handleClose = useCallback(() => setIsCreating(false), [setIsCreating]);
+  return <AddClassesModalComponent isOpen={isCreating} onClose={handleClose} />;
+};
 
 export const LabelClassesActions = () => {
-  const { searchText, setSearchText, isCreating, setIsCreating } =
-    useDatasetClasses();
+  const { searchText, setSearchText, setIsCreating } = useDatasetClasses();
+  const handleAdd = useCallback(() => setIsCreating(true), [setIsCreating]);
   return (
     <>
-      <UpsertClassModal
-        isOpen={isCreating}
-        onClose={() => setIsCreating(false)}
-      />
+      <AddClassesModal />
       <TableActions
         searchText={searchText}
         setSearchText={setSearchText}
-        onNewItem={() => setIsCreating(true)}
+        onNewItem={handleAdd}
         searchBarLabel="Find a class"
         newButtonLabel="New class"
-      />
+      >
+        <DownloadAction />
+      </TableActions>
     </>
   );
 };

--- a/typescript/web/src/components/export-button/export-modal/export-dataset.ts
+++ b/typescript/web/src/components/export-button/export-modal/export-dataset.ts
@@ -8,8 +8,7 @@ import {
   ExportFormat,
   ExportOptions,
 } from "../../../graphql-types/globalTypes";
-
-import { getDatasetExportName } from "./get-dataset-export-name";
+import { getDatasetExportName, triggerClientDownload } from "../../../utils";
 
 export const EXPORT_DATASET_URL_QUERY = gql`
   query ExportDatasetUrlQuery(
@@ -77,11 +76,7 @@ export const exportDataset = async ({
     }
   );
   const blobDataset = await (await fetch(exportDatasetUrl)).blob();
-  const url = window.URL.createObjectURL(blobDataset);
-  const element = document.createElement("a");
   const extension = getExtension(format, options);
-  element.href = url;
-  element.download = `${datasetName}.${extension}`;
+  triggerClientDownload(blobDataset, `${datasetName}.${extension}`);
   setIsExportRunning(false);
-  element.click();
 };

--- a/typescript/web/src/components/export-button/export-modal/export-modal.fixtures.ts
+++ b/typescript/web/src/components/export-button/export-modal/export-modal.fixtures.ts
@@ -15,7 +15,7 @@ import {
 import { EXPORT_DATASET_URL_QUERY } from "./export-dataset";
 import { COUNT_LABELS_OF_DATASET_QUERY } from "./export-modal.context";
 import { DEFAULT_EXPORT_OPTIONS } from "./formats";
-import { getDatasetExportName } from "./get-dataset-export-name";
+import { getDatasetExportName } from "../../../utils";
 
 const datasetName = getDatasetExportName(BASIC_DATASET_DATA.slug);
 

--- a/typescript/web/src/components/reorderable-table/reorderable-table-body.tsx
+++ b/typescript/web/src/components/reorderable-table/reorderable-table-body.tsx
@@ -18,7 +18,12 @@ export const ReorderableTableBody = ({
     <Droppable droppableId="reorderableTable" direction="vertical" type="ROW">
       {({ innerRef, droppableProps, placeholder }) => (
         <>
-          <Tbody ref={innerRef} {...droppableProps} {...props}>
+          <Tbody
+            data-testid="reorderable-table-body"
+            ref={innerRef}
+            {...droppableProps}
+            {...props}
+          >
             {children}
             {placeholder}
           </Tbody>

--- a/typescript/web/src/components/table-actions/index.tsx
+++ b/typescript/web/src/components/table-actions/index.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   ButtonGroup,
+  ButtonProps,
   chakra,
   FormControl,
   FormLabel,
@@ -11,7 +12,8 @@ import {
   Stack,
   useColorModeValue as mode,
 } from "@chakra-ui/react";
-import { createContext, useContext } from "react";
+import { createContext, PropsWithChildren, useContext } from "react";
+import { IconType } from "react-icons/lib";
 import { IoSearch } from "react-icons/io5";
 import { RiAddFill } from "react-icons/ri";
 
@@ -36,6 +38,7 @@ const SearchBar = () => {
             <SearchIcon />
           </InputLeftElement>
           <Input
+            data-testid="search-input"
             rounded="base"
             type="search"
             placeholder={searchBarLabel}
@@ -49,32 +52,60 @@ const SearchBar = () => {
   );
 };
 
-const NewItemButton = () => {
+export type ActionButtonVariant = "brand" | "outline";
+
+export type ActionButtonProps = Pick<ButtonProps, "onClick" | "disabled"> & {
+  label: string;
+  icon: IconType;
+  variant: ActionButtonVariant;
+};
+
+export const TableActionButton = ({
+  label,
+  icon,
+  variant,
+  ...props
+}: ActionButtonProps) => {
+  const Icon = chakra(icon);
+  return (
+    <Button
+      variant="solid"
+      iconSpacing="1"
+      colorScheme={variant === "brand" ? "brand" : undefined}
+      bgColor={variant === "outline" ? mode("white", "gray.800") : undefined}
+      leftIcon={<Icon fontSize="md" />}
+      {...props}
+    >
+      {label}
+    </Button>
+  );
+};
+
+const Buttons = ({ children }: PropsWithChildren<{}>) => {
   const { onNewItem, newButtonLabel } = useContext(TableActionsContext);
   return (
     <ButtonGroup size="sm" variant="outline">
-      <Button
-        colorScheme="brand"
-        variant="solid"
-        iconSpacing="1"
-        leftIcon={<RiAddFill fontSize="1.25em" />}
+      {children}
+      <TableActionButton
+        data-testid="add-button"
+        variant="brand"
+        icon={RiAddFill}
         onClick={onNewItem}
-      >
-        {newButtonLabel}
-      </Button>
+        label={newButtonLabel}
+      />
     </ButtonGroup>
   );
 };
 
-export type TableActionsProps = {
+export type TableActionsProps = PropsWithChildren<{
   searchText: string;
   setSearchText: (text: string) => void;
   onNewItem: () => void;
   searchBarLabel: string;
   newButtonLabel: string;
-};
+}>;
 
-export const TableActions = (props: TableActionsProps) => {
+export const TableActions = ({ children, ...props }: TableActionsProps) => {
   return (
     <TableActionsContext.Provider value={props}>
       <Stack
@@ -83,7 +114,7 @@ export const TableActions = (props: TableActionsProps) => {
         justify="space-between"
       >
         <SearchBar />
-        <NewItemButton />
+        <Buttons>{children}</Buttons>
       </Stack>
     </TableActionsContext.Provider>
   );

--- a/typescript/web/src/utils/export/export-names.test.ts
+++ b/typescript/web/src/utils/export/export-names.test.ts
@@ -1,5 +1,8 @@
 import { initMockedDate } from "@labelflow/dev-utils/mockdate";
-import { getDatasetExportName } from "./get-dataset-export-name";
+import {
+  getDatasetClassesExportName,
+  getDatasetExportName,
+} from "./export-names";
 
 initMockedDate();
 
@@ -9,5 +12,12 @@ describe(getDatasetExportName, () => {
   it("returns the correct name", () => {
     const exportName = getDatasetExportName(DATASET_SLUG);
     expect(exportName).toBe("my-dataset-slug-2021-05-31T120000");
+  });
+});
+
+describe(getDatasetClassesExportName, () => {
+  it("returns the correct name", () => {
+    const exportName = getDatasetClassesExportName(DATASET_SLUG);
+    expect(exportName).toBe("my-dataset-slug-classes-2021-05-31T120000");
   });
 });

--- a/typescript/web/src/utils/export/export-names.ts
+++ b/typescript/web/src/utils/export/export-names.ts
@@ -4,3 +4,8 @@ export const getDatasetExportName = (datasetSlug: string) => {
   const dateAndTime = format(new Date(), "yyyy-MM-dd'T'hhmmss");
   return `${datasetSlug}-${dateAndTime}`;
 };
+
+export const getDatasetClassesExportName = (datasetSlug: string) => {
+  const dateAndTime = format(new Date(), "yyyy-MM-dd'T'hhmmss");
+  return `${datasetSlug}-classes-${dateAndTime}`;
+};

--- a/typescript/web/src/utils/export/index.ts
+++ b/typescript/web/src/utils/export/index.ts
@@ -1,0 +1,1 @@
+export * from "./export-names";

--- a/typescript/web/src/utils/index.ts
+++ b/typescript/web/src/utils/index.ts
@@ -1,1 +1,3 @@
 export * from "./optional-parent";
+export * from "./export";
+export * from "./trigger-client-download";

--- a/typescript/web/src/utils/trigger-client-download.ts
+++ b/typescript/web/src/utils/trigger-client-download.ts
@@ -1,0 +1,6 @@
+export const triggerClientDownload = (fileData: Blob, fileName: string) => {
+  const element = document.createElement("a");
+  element.href = window.URL.createObjectURL(fileData);
+  element.download = fileName;
+  element.click();
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -8185,6 +8185,7 @@ __metadata:
     browser-builtins: 3.3.1
     bundlewatch: 0.3.2
     change-case: 4.1.2
+    csv-stringify: 6.0.5
     date-fns: 2.23.0
     detect-browser: 5.2.0
     dotenv-cli: 4.0.0


### PR DESCRIPTION
## Work performed

- Add a CSV export feature to dataset label classes.
- Allow creating multiple classes at once from a list of names.
- Add a "createManyLabelClasses" mutation.
- Enforce check of duplicate LabelClass names within a dataset at creating time.

## Results

- We can export/download classes on the dataset label classes pages, in the CSV format.
- Class creation form the dataset classes page is now made using a list of multiple classes.

## Caveats

When inserting multiple new label classes the cache of the current dataset is entirely evicted.

## Resolved issues

Resolves #905
