### PR TITLE
Remove buggy auto-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,44 +355,17 @@ jobs:
   #         deployment_id: ${{ steps.deployment.outputs.deployment_id }}
   #         env_url: ${{steps.vercel.outputs.preview-url}}
 
-  bump-version:
-    name: "Bump version (only on main)"
-    if: contains( github.ref, 'main')
-    runs-on: ubuntu-20.04
-    needs:
-      [
-        lint-typescript,
-        lint-python,
-        test-typescript,
-        check-codegen-diff,
-        e2e-analysis,
-      ]
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.SUPER_GITHUB_TOKEN }}
-      - name: Fetch node_modules from cache
-        uses: actions/cache@v2
-        id: node-modules-cache
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-modules-${{secrets.ACTIONS_CACHE_VERSION}}-${{ hashFiles('yarn.lock') }}
-      - name: Configure Git
-        run: |
-          git config user.name "Hugo Raynal"
-          git config user.email "hugo.raynal@labelflow.ai"
-      - name: Bump version
-        run: yarn release patch
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   deploy-chromatic-main:
     name: Deploy Storybook production
     if: contains( github.ref, 'main')
     runs-on: ubuntu-20.04
-    needs: bump-version
+    needs: [
+      lint-typescript,
+      lint-python,
+      test-typescript,
+      check-codegen-diff,
+      e2e-analysis,
+    ]
     # Job steps
     steps:
       - uses: actions/checkout@v2
@@ -420,7 +393,13 @@ jobs:
     name: Deploy Strapi on Heroku production
     if: contains( github.ref, 'main')
     runs-on: ubuntu-20.04
-    needs: bump-version
+    needs: [
+      lint-typescript,
+      lint-python,
+      test-typescript,
+      check-codegen-diff,
+      e2e-analysis,
+    ]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2


### PR DESCRIPTION
## Work performed

<!--- Concisely describe what was done, this will appear in the public changelog -->
I've removed the auto-release from GitHub CI as it was failing and because it could trigger unwanted revision bumps.
This way the whole CI would pass on main.

## Results

<!--- Does this pull-request fully implement the new feature? If not why? Create and link new issues. -->
Releases and tags can't be created anymore (they already weren't for months actually)

## Problems encountered

<!--- Explain problems that were encountered when implementing this pull-request -->
No

## Caveats

<!--- Any particular attention point with what you did? -->
No

## Resolved issues

<!--- List references to issues that this PR resolves -->
No

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
We should think about how tell which kind of version bump should occur once we write our commits. They are tools for this but it needs investigation.