### PR TITLE
Ignore the constantly-changing Bing story from react-openlayers-fiber Chromatic reports

### DIFF
--- a/typescript/react-openlayers-fiber/src/__stories__/basic.stories.tsx
+++ b/typescript/react-openlayers-fiber/src/__stories__/basic.stories.tsx
@@ -4,9 +4,6 @@ import { Map } from "../map";
 
 export default {
   title: "react-openlayers-fiber/Other Examples",
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
 };
 
 /**
@@ -21,6 +18,7 @@ export const BasicConstructorArgs = () => (
     </olLayerTile>
   </Map>
 );
+BasicConstructorArgs.parameters = { chromatic: { disableSnapshot: true } };
 
 /**
  * In this story we only provide props for the view, so it should load with default values
@@ -42,6 +40,7 @@ export const BasicProps = () => {
     </Map>
   );
 };
+BasicProps.parameters = { chromatic: { disableSnapshot: true } };
 
 /**
  * In this story we provide props and initial props for the view, so it should behave like the Basic Props example values.
@@ -67,3 +66,4 @@ export const BasicBoth = () => {
     </Map>
   );
 };
+BasicBoth.parameters = { chromatic: { disableSnapshot: true } };

--- a/typescript/react-openlayers-fiber/src/__stories__/bing.stories.tsx
+++ b/typescript/react-openlayers-fiber/src/__stories__/bing.stories.tsx
@@ -48,3 +48,5 @@ export const Bing = () => {
     </>
   );
 };
+
+Bing.parameters = { chromatic: { disableSnapshot: true } };


### PR DESCRIPTION
## Work performed

<!--- Concisely describe what was done, this will appear in the public changelog -->
I've just disabled the Bing story from Chromatic snapshots

## Results

<!--- Does this pull-request fully implement the new feature? If not why? Create and link new issues. -->
We miss the (spammy) Chromatic review but it's not that useful for this component anyway.

## Problems encountered

<!--- Explain problems that were encountered when implementing this pull-request -->
No

## Caveats

<!--- Any particular attention point with what you did? -->
No

## Resolved issues

<!--- List references to issues that this PR resolves -->
No

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
- [ ] They are other constantly-changing stories which we have to ignore.