### PR TITLE
Update zustand-store-addons to version 0.1.12

### DIFF
--- a/typescript/web/package.json
+++ b/typescript/web/package.json
@@ -104,7 +104,7 @@
     "uuid": "8.3.2",
     "valid-url": "1.0.9",
     "zustand": "3.5.1",
-    "zustand-store-addons": "0.1.11"
+    "zustand-store-addons": "0.1.12"
   },
   "devDependencies": {
     "@labelflow/dev-utils": "workspace:typescript/dev-utils",

--- a/typescript/web/src/connectors/labeling-state/index.ts
+++ b/typescript/web/src/connectors/labeling-state/index.ts
@@ -1,7 +1,5 @@
 import { View as OlView } from "ol";
 import { zoomByDelta as olZoomByDelta } from "ol/interaction/Interaction";
-// Needed to correct https://github.com/Diablow/zustand-store-addons/issues/2
-import type { UseStore } from "zustand";
 import create from "zustand-store-addons";
 import { Coordinate } from "ol/coordinate";
 
@@ -86,7 +84,6 @@ export const useLabelingStore = create<LabelingState>(
         ...iogSpinnerPositions,
         [timestamp]: iogSpinnerPosition,
       };
-      // @ts-ignore See https://github.com/Diablow/zustand-store-addons/issues/2
       set({
         iogProcessingLabels,
         iogSpinnerPositions: newIogSpinnerPositions,
@@ -102,7 +99,6 @@ export const useLabelingStore = create<LabelingState>(
           )
           .map((key) => [key, iogSpinnerPositions[parseInt(key, 10)]])
       );
-      // @ts-ignore See https://github.com/Diablow/zustand-store-addons/issues/2
       return set({
         iogSpinnerPositions: newIogSpinnerPositions,
         iogProcessingLabels,
@@ -110,38 +106,27 @@ export const useLabelingStore = create<LabelingState>(
     },
     isContextMenuOpen: false,
     setIsContextMenuOpen: (isContextMenuOpen: boolean) =>
-      // @ts-ignore See https://github.com/Diablow/zustand-store-addons/issues/2
       set({ isContextMenuOpen }),
     contextMenuLocation: undefined,
     setContextMenuLocation: (contextMenuLocation: Coordinate | undefined) =>
-      // @ts-ignore See https://github.com/Diablow/zustand-store-addons/issues/2
       set({ contextMenuLocation }),
     selectedTool: getRouterValue("selectedTool") ?? Tools.SELECTION,
     selectedLabelId: getRouterValue("selectedLabelId") ?? null,
     selectedLabelClassId: getRouterValue("selectedLabelClassId") ?? null,
     boxDrawingToolState: DrawingToolState.IDLE,
     setDrawingToolState: (boxDrawingToolState: DrawingToolState) =>
-      // @ts-ignore See https://github.com/Diablow/zustand-store-addons/issues/2
       set({ boxDrawingToolState }),
     selectionToolState: SelectionToolState.DEFAULT,
     setSelectionToolState: (selectionToolState: SelectionToolState) =>
-      // @ts-ignore See https://github.com/Diablow/zustand-store-addons/issues/2
       set({ selectionToolState }),
-    // @ts-ignore See https://github.com/Diablow/zustand-store-addons/issues/2
     setView: (view: OlView) => set({ view }),
-    // @ts-ignore See https://github.com/Diablow/zustand-store-addons/issues/2
     setSelectedTool: (selectedTool: Tools) => set({ selectedTool }),
     setSelectedLabelId: (selectedLabelId: string | null) =>
-      // @ts-ignore See https://github.com/Diablow/zustand-store-addons/issues/2
       set({ selectedLabelId }),
     setSelectedLabelClassId: (labelClassId: string | null) =>
-      // @ts-ignore See https://github.com/Diablow/zustand-store-addons/issues/2
       set({ selectedLabelClassId: labelClassId }),
-    // @ts-ignore See https://github.com/Diablow/zustand-store-addons/issues/2
     setCanZoomIn: (canZoomIn: boolean) => set({ canZoomIn }),
-    // @ts-ignore See https://github.com/Diablow/zustand-store-addons/issues/2
     setCanZoomOut: (canZoomOut: boolean) => set({ canZoomOut }),
-    // @ts-ignore See https://github.com/Diablow/zustand-store-addons/issues/2
     setIsImageLoading: (isImageLoading: boolean) => set({ isImageLoading }),
     zoomByDelta: (ratio: number) => {
       const { view } = get();
@@ -159,13 +144,10 @@ export const useLabelingStore = create<LabelingState>(
       //   3. geometry and name hidden
       const { showLabelsGeometry, showLabelsName } = get();
       if (showLabelsGeometry && showLabelsName) {
-        // @ts-ignore See https://github.com/Diablow/zustand-store-addons/issues/2
         set({ showLabelsName: false });
       } else if (showLabelsGeometry && !showLabelsName) {
-        // @ts-ignore See https://github.com/Diablow/zustand-store-addons/issues/2
         set({ showLabelsGeometry: false });
       } else if (!showLabelsGeometry && !showLabelsName) {
-        // @ts-ignore See https://github.com/Diablow/zustand-store-addons/issues/2
         set({ showLabelsGeometry: true, showLabelsName: true });
       } else {
         // If you change the code above, take care to respect the cycle described
@@ -192,4 +174,4 @@ export const useLabelingStore = create<LabelingState>(
       selectedLabelClassId: setRouterValue("selectedLabelClassId"),
     },
   }
-) as UseStore<LabelingState>; // Needed to correct https://github.com/Diablow/zustand-store-addons/issues/2
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8339,7 +8339,7 @@ __metadata:
     webpack-node-externals: 3.0.0
     wildcard-mock-link: 2.0.2
     zustand: 3.5.1
-    zustand-store-addons: 0.1.11
+    zustand-store-addons: 0.1.12
   languageName: unknown
   linkType: soft
 
@@ -36935,16 +36935,16 @@ typescript@~3.7.3:
   languageName: node
   linkType: hard
 
-"zustand-store-addons@npm:0.1.11":
-  version: 0.1.11
-  resolution: "zustand-store-addons@npm:0.1.11"
+"zustand-store-addons@npm:0.1.12":
+  version: 0.1.12
+  resolution: "zustand-store-addons@npm:0.1.12"
   dependencies:
     lodash-es: ^4.17.15
     string.prototype.matchall: ^4.0.2
   peerDependencies:
     react: ">=16"
     zustand: ">=3.0.0"
-  checksum: d2c20ff9695a2595f0fd5e2f5d4b6d24a62a9e575c8e579db07f7bdd9bdbb9a32e64a75eb8b2de1d765c928a26b2a73024e33aa241c408f4ef05bf120f78535a
+  checksum: 2f10cef0ab20b9046ae9e35cc0899c22fe0ad7c80f41790092cbd188355f49470820c03843ddda7683360040b8ab4730600ebbc823f4365ed01d451ebcaf36f0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Work performed

<!--- Concisely describe what was done, this will appear in the public changelog -->
Following my PR on upstream repo ( https://github.com/Diablow/zustand-store-addons/pull/6 ), I'm now propagating the changes on our codebase.

## Results

<!--- Does this pull-request fully implement the new feature? If not why? Create and link new issues. -->
No more `// ts-ignore` in `typescript/web/src/connectors/labeling-state/index.ts`.

## Problems encountered

<!--- Explain problems that were encountered when implementing this pull-request -->
No

## Caveats

<!--- Any particular attention point with what you did? -->
No

## Resolved issues

<!--- List references to issues that this PR resolves -->
No but it confirms that https://github.com/Diablow/zustand-store-addons/issues/2 is fixed

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
No