### PR TITLE
Use correct color in alternate import file status row

### DIFF
--- a/typescript/web/src/components/import-button/import-images-modal/import-images-modal.stories.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/import-images-modal.stories.tsx
@@ -1,11 +1,12 @@
 import { Button, useDisclosure } from "@chakra-ui/react";
 import { BASIC_DATASET_DATA, WORKSPACE_DATA } from "../../../utils/fixtures";
 import { createCommonDecorator, storybookTitle } from "../../../utils/stories";
+import { ImportButton } from "../import-button";
 import { IMPORT_BUTTON_MOCKS } from "../import-button.fixtures";
 import { ImportImagesModal } from "./import-images-modal";
 
 export default {
-  title: storybookTitle(ImportImagesModal),
+  title: storybookTitle(ImportButton, ImportImagesModal),
   parameters: {
     nextRouter: {
       path: "/images/[id]",

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/file-statuses.stories.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/file-statuses.stories.tsx
@@ -1,0 +1,39 @@
+import { Box } from "@chakra-ui/react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { range } from "lodash/fp";
+import { chakraDecorator, storybookTitle } from "../../../../utils/stories";
+import { ImportButton } from "../../import-button";
+import { DroppedFile } from "../types";
+import { FilesStatuses as FilesStatusesComponent } from "./file-statuses";
+
+export default {
+  title: storybookTitle(ImportButton, FilesStatusesComponent),
+  component: FilesStatusesComponent,
+  decorators: [chakraDecorator],
+} as ComponentMeta<typeof FilesStatusesComponent>;
+
+const Template: ComponentStory<typeof FilesStatusesComponent> = (args) => (
+  <Box maxW="xl">
+    <FilesStatusesComponent {...args} />
+  </Box>
+);
+
+export const FilesStatuses = Template.bind({});
+FilesStatuses.args = {
+  files: range(0, 5).map((index) => ({
+    file: {
+      name: `file-${index}.jpg`,
+      path: `/src/file-${index}.jpg`,
+    } as DroppedFile["file"],
+    errors: [],
+  })),
+  uploadInfo: {
+    "/src/file-0.jpg": { status: "loading" },
+    "/src/file-1.jpg": { status: "uploaded" },
+    "/src/file-2.jpg": {
+      status: "uploaded",
+      warnings: ["File 2 has been uploaded but it looks corrupted"],
+    },
+    "/src/file-3.jpg": { status: "error" },
+  },
+};

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/file-statuses.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/file-statuses.tsx
@@ -93,7 +93,7 @@ const FileStatus = ({ droppedFile, index, uploadInfo }: FileStatusProps) => {
     droppedFile.file,
     !isEmpty(droppedFile.errors)
   );
-  const bg = useColorModeValue("red.500", "red.300");
+  const bg = useColorModeValue("gray.50", "gray.700");
   return (
     <>
       <Flex

--- a/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/file-statuses.tsx
+++ b/typescript/web/src/components/import-button/import-images-modal/modal-dropzone/file-statuses.tsx
@@ -114,12 +114,12 @@ const FileStatus = ({ droppedFile, index, uploadInfo }: FileStatusProps) => {
   );
 };
 
-export type UploadInfoProps = {
+export type FilesStatusesProps = {
   files: Array<DroppedFile>;
   uploadInfo: UploadInfoRecord;
 };
 
-export const FilesStatuses = ({ files, uploadInfo }: UploadInfoProps) => (
+export const FilesStatuses = ({ files, uploadInfo }: FilesStatusesProps) => (
   <Flex direction="column" height="100%">
     <Box
       p="2"


### PR DESCRIPTION
## Work performed

<!--- Concisely describe what was done, this will appear in the public changelog -->
I've rolled-back out the color of the alternate row representing a file import status which was broken:

![image](https://user-images.githubusercontent.com/2091902/160865228-a79d74a5-2554-420a-a7fb-af61fbe86f4f.png)

## Results

<!--- Does this pull-request fully implement the new feature? If not why? Create and link new issues. -->
Color should be OK now

## Problems encountered

<!--- Explain problems that were encountered when implementing this pull-request -->
No

## Caveats

<!--- Any particular attention point with what you did? -->
No

## Resolved issues

<!--- List references to issues that this PR resolves -->


## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
No