### PR TITLE
Store AiAssistant ID in db when creating new labels

### DIFF
--- a/typescript/db/migrations/20220404081825_label_ai_assistant_id/migration.sql
+++ b/typescript/db/migrations/20220404081825_label_ai_assistant_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Label" ADD COLUMN     "aiAssistantId" UUID;

--- a/typescript/db/schema.prisma
+++ b/typescript/db/schema.prisma
@@ -55,6 +55,7 @@ model Label {
   image          Image       @relation(fields: [imageId], references: [id], onDelete: Cascade)
   labelClass     LabelClass? @relation(fields: [labelClassId], references: [id], onDelete: Cascade)
   smartToolInput Json?
+  aiAssistantId  String?     @db.Uuid
 
   @@index([labelClassId])
   @@index([imageId, createdAt])


### PR DESCRIPTION
## Work performed

<!--- Concisely describe what was done, this will appear in the public changelog -->
I've added the AI Assistant ID in the `Label` entity of the DB schema.

## Results

<!--- Does this pull-request fully implement the new feature? If not why? Create and link new issues. -->
We can now acknowledge that a label has been created with an AiAssistant.

## Problems encountered

<!--- Explain problems that were encountered when implementing this pull-request -->

## Caveats

<!--- Any particular attention point with what you did? -->
DB relations are not complete as we don't store AI Assistant in it yet.

## Resolved issues

<!--- List references to issues that this PR resolves -->
_No issue opened for it AFAIK but it's related with #958_

## Newly raised issues

<!--- List references to issues that where opened when creating this PR -->
No